### PR TITLE
feat(kubernetes): set kubernetes_ca_cert as sensitive

### DIFF
--- a/apis/kubernetes/v1alpha1/zz_authbackendconfig_types.go
+++ b/apis/kubernetes/v1alpha1/zz_authbackendconfig_types.go
@@ -29,9 +29,6 @@ type AuthBackendConfigObservation struct {
 	// Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount will be used as the default issuer.
 	Issuer *string `json:"issuer,omitempty" tf:"issuer,omitempty"`
 
-	// PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.
-	KubernetesCACert *string `json:"kubernetesCaCert,omitempty" tf:"kubernetes_ca_cert,omitempty"`
-
 	// Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
 	KubernetesHost *string `json:"kubernetesHost,omitempty" tf:"kubernetes_host,omitempty"`
 
@@ -62,7 +59,7 @@ type AuthBackendConfigParameters struct {
 
 	// PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.
 	// +kubebuilder:validation:Optional
-	KubernetesCACert *string `json:"kubernetesCaCert,omitempty" tf:"kubernetes_ca_cert,omitempty"`
+	KubernetesCACertSecretRef *v1.SecretKeySelector `json:"kubernetesCaCertSecretRef,omitempty" tf:"-"`
 
 	// Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
 	// +kubebuilder:validation:Optional

--- a/apis/kubernetes/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/kubernetes/v1alpha1/zz_generated.deepcopy.go
@@ -101,11 +101,6 @@ func (in *AuthBackendConfigObservation) DeepCopyInto(out *AuthBackendConfigObser
 		*out = new(string)
 		**out = **in
 	}
-	if in.KubernetesCACert != nil {
-		in, out := &in.KubernetesCACert, &out.KubernetesCACert
-		*out = new(string)
-		**out = **in
-	}
 	if in.KubernetesHost != nil {
 		in, out := &in.KubernetesHost, &out.KubernetesHost
 		*out = new(string)
@@ -162,9 +157,9 @@ func (in *AuthBackendConfigParameters) DeepCopyInto(out *AuthBackendConfigParame
 		*out = new(string)
 		**out = **in
 	}
-	if in.KubernetesCACert != nil {
-		in, out := &in.KubernetesCACert, &out.KubernetesCACert
-		*out = new(string)
+	if in.KubernetesCACertSecretRef != nil {
+		in, out := &in.KubernetesCACertSecretRef, &out.KubernetesCACertSecretRef
+		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
 	if in.KubernetesHost != nil {

--- a/apis/kubernetes/v1alpha1/zz_generated_terraformed.go
+++ b/apis/kubernetes/v1alpha1/zz_generated_terraformed.go
@@ -20,7 +20,7 @@ func (mg *AuthBackendConfig) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this AuthBackendConfig
 func (tr *AuthBackendConfig) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"token_reviewer_jwt": "spec.forProvider.tokenReviewerJwtSecretRef"}
+	return map[string]string{"kubernetes_ca_cert": "spec.forProvider.kubernetesCaCertSecretRef", "token_reviewer_jwt": "spec.forProvider.tokenReviewerJwtSecretRef"}
 }
 
 // GetObservation of this AuthBackendConfig

--- a/config/kubernetesauthbackendconfig/config.go
+++ b/config/kubernetesauthbackendconfig/config.go
@@ -5,8 +5,6 @@ import "github.com/upbound/upjet/pkg/config"
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("vault_kubernetes_auth_backend_config", func(r *config.Resource) {
-		// We need to override the default group that upjet generated for
-		// this resource, which would be "vault"
 		r.TerraformResource.Schema["kubernetes_ca_cert"].Sensitive = true
 	})
 }

--- a/config/kubernetesauthbackendconfig/config.go
+++ b/config/kubernetesauthbackendconfig/config.go
@@ -1,0 +1,12 @@
+package kubernetesauthbackendconfig
+
+import "github.com/upbound/upjet/pkg/config"
+
+// Configure configures individual resources by adding custom ResourceConfigurators.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("vault_kubernetes_auth_backend_config", func(r *config.Resource) {
+		// We need to override the default group that upjet generated for
+		// this resource, which would be "vault"
+		r.TerraformResource.Schema["kubernetes_ca_cert"].Sensitive = true
+	})
+}

--- a/config/provider.go
+++ b/config/provider.go
@@ -8,6 +8,7 @@ import (
 	// Note(turkenh): we are importing this to embed provider schema document
 	_ "embed"
 
+	"github.com/upbound/provider-vault/config/kubernetesauthbackendconfig"
 	ujconfig "github.com/upbound/upjet/pkg/config"
 )
 
@@ -33,6 +34,7 @@ func GetProvider() *ujconfig.Provider {
 
 	for _, configure := range []func(provider *ujconfig.Provider){
 		// add custom config functions
+		kubernetesauthbackendconfig.Configure,
 	} {
 		configure(pc)
 	}

--- a/package/crds/kubernetes.vault.upbound.io_authbackendconfigs.yaml
+++ b/package/crds/kubernetes.vault.upbound.io_authbackendconfigs.yaml
@@ -83,10 +83,24 @@ spec:
                     description: Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount
                       will be used as the default issuer.
                     type: string
-                  kubernetesCaCert:
+                  kubernetesCaCertSecretRef:
                     description: PEM encoded CA cert for use by the TLS client used
                       to talk with the Kubernetes API.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   kubernetesHost:
                     description: Host must be a host string, a host:port pair, or
                       a URL to the base of the Kubernetes API server.
@@ -332,10 +346,6 @@ spec:
                   issuer:
                     description: Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount
                       will be used as the default issuer.
-                    type: string
-                  kubernetesCaCert:
-                    description: PEM encoded CA cert for use by the TLS client used
-                      to talk with the Kubernetes API.
                     type: string
                   kubernetesHost:
                     description: Host must be a host string, a host:port pair, or


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
https://crossplane.slack.com/archives/C01TRKD4623/p1690290399596229

> building a poc for managing vault config via crossplane, i m trying to deploy this https://marketplace.upbound.io/providers/upbound/provider-vault/v0.1.0/resources/kubernetes.vault.upbound.io/AuthBackendConfig/v1alpha1 resource and was wondering how can we specify spec.forProvider.kubernetesCaCert via a configmap/secret rather than raw values

switched `kubernetesCaCert` as sensitive - that its possible to set via kubernetes secret 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
create & delete

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
