### PR TITLE
Parse credentials as map[string]any{}

### DIFF
--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -122,7 +122,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			return ps, errors.Wrap(err, errExtractCredentials)
 		}
 
-		creds := map[string]string{}
+		creds := map[string]any{}
 		if err := json.Unmarshal(data, &creds); err != nil {
 			return ps, errors.Wrap(err, errUnmarshalCredentials)
 		}


### PR DESCRIPTION
### Description of your changes

Currently, it is not possible to use a credential value other than string in ProviderConfig.

Using the following provider config secret, fails with the following error:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: vault-creds
  namespace: vault
type: Opaque
stringData:
  # WARNING: DO NOT CHECK REAL TOKENS INTO GIT
  credentials: |
    {"auth_login":{"path":"auth/approle/login","namespace":"NAMESPACE","parameters":{"role_id":"ROLE_ID","secret_id":"SECRET_ID"}}}
```

```
2023-08-10T08:50:43Z	DEBUG	events	cannot get terraform setup: cannot unmarshal vault credentials as JSON: json: cannot unmarshal object into Go value of type string	{"type": "Warning", "object": {"kind":"Mount","name":"kv-v2-secret-mount","uid":"8ea6a132-c6cf-49c9-83d3-
```

This PR fixes credential parsing by using `map[string]any{}` as it type.
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

To be tested, built provider image `turkenh/provider-vault:v0.0.0-50.g8d5443d` from this PR.

[contribution process]: https://git.io/fj2m9
