### PR TITLE
feat(go): set go 1.20 also for e2e uptest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.53.3'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_REQUIRED_VERSION ?= 1.19
+GO_REQUIRED_VERSION ?= 1.20
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis

--- a/examples/auth/authbackend.yaml
+++ b/examples/auth/authbackend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: github-generic-auth-backend
 spec:
   forProvider:
-    description: "GitHub generic auth backend for UXP manageed Vault"
+    description: "GitHub generic auth backend for UXP managed Vault"
     type: "github"
   providerConfigRef:
     name: vault-provider-config

--- a/examples/githubauthbackend/githubauthbackend.yaml
+++ b/examples/githubauthbackend/githubauthbackend.yaml
@@ -8,7 +8,7 @@ metadata:
   name: github-specific-auth-backend
 spec:
   forProvider:
-    description: "GitHub specific auth backend for UXP manageed Vault"
+    description: "GitHub specific auth backend for UXP managed Vault"
     path: "auth/github-specific"
     organization: default-org-test
   providerConfigRef:

--- a/examples/githubteam/githubteam.yaml
+++ b/examples/githubteam/githubteam.yaml
@@ -23,7 +23,7 @@ metadata:
   name: github-team
 spec:
   forProvider:
-    description: "GitHub generic auth backend for UXP manageed Vault"
+    description: "GitHub generic auth backend for UXP managed Vault"
     type: "github"
   providerConfigRef:
     name: vault-provider-config

--- a/examples/kvsecret/kvsecret.yaml
+++ b/examples/kvsecret/kvsecret.yaml
@@ -28,6 +28,6 @@ spec:
   deletionPolicy: Delete
   forProvider:
     path: "kvv1"
-    type: "kv-v1"
+    type: "kv"
   providerConfigRef:
     name: vault-provider-config


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- set go 1.20 also for e2e uptest via https://github.com/upbound/provider-vault/pull/17
- fix typos `manageed` -> `managed` in examples
- switch type `kv-v1` to `kv` because of the following error after first reconcile loop:

```
  # vault_mount.vault-creds-kv1 must be replaced
-/+ resource "vault_mount" "vault-creds-kv1" {
      ~ accessor                     = "kv_425e40b5" -> (known after apply)
      - allowed_managed_keys         = [] -> null
      ~ audit_non_hmac_request_keys  = [] -> (known after apply)
      ~ audit_non_hmac_response_keys = [] -> (known after apply)
      ~ default_lease_ttl_seconds    = 0 -> (known after apply)
      ~ id                           = "kvv1" -> (known after apply)
      - local                        = false -> null
      ~ max_lease_ttl_seconds        = 0 -> (known after apply)
      ~ seal_wrap                    = false -> (known after apply)
      ~ type                         = "kv" -> "kv-v1" # forces replacement
```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
