### PR TITLE
fix: broken JSON in ProviderConfig example

### DIFF
--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -16,7 +16,7 @@ stringData:
     #  "auth_login": {
     #    "path": "auth/approle/login",
     #    "parameters": {
-    #      "role_id": ""
+    #      "role_id": "",
     #      "secret_id": ""
     #    }
     #  }


### PR DESCRIPTION
### Description of your changes
Fixes missing comma in ProviderConfig JSON credential example.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.


[contribution process]: https://git.io/fj2m9
