### PR TITLE
feat: get canonical id from group resource

### DIFF
--- a/apis/identity/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/identity/v1alpha1/zz_generated.deepcopy.go
@@ -940,6 +940,7 @@ func (in *GroupAliasParameters) DeepCopyInto(out *GroupAliasParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	out.CanonicalIDFromGroupRef = in.CanonicalIDFromGroupRef
 	if in.MountAccessor != nil {
 		in, out := &in.MountAccessor, &out.MountAccessor
 		*out = new(string)

--- a/apis/identity/v1alpha1/zz_groupalias_types.go
+++ b/apis/identity/v1alpha1/zz_groupalias_types.go
@@ -67,6 +67,10 @@ type GroupAliasParameters struct {
 	// +kubebuilder:validation:Optional
 	CanonicalID *string `json:"canonicalId,omitempty" tf:"canonical_id,omitempty"`
 
+	// Reference to a Group in identity to populate canonicalIdFromGroupRef.
+	// +kubebuilder:validation:Optional
+	CanonicalIDFromGroupRef *v1.Reference `json:"canonicalIdFromGroupRef,omitempty" tf:"-"`
+
 	// Mount accessor of the authentication backend to which this alias belongs to.
 	// Mount accessor to which this alias belongs to.
 	// +kubebuilder:validation:Optional

--- a/config/vault/config.go
+++ b/config/vault/config.go
@@ -1,11 +1,21 @@
 package vault
 
-import "github.com/upbound/upjet/pkg/config"
+import (
+	"github.com/upbound/upjet/pkg/config"
+)
 
 // ConfigureNamespace configures the namespace resource.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("vault_namespace", func(r *config.Resource) {
 		r.Kind = "VaultNamespace"
 		r.ShortGroup = "vault"
+	})
+	p.AddResourceConfigurator("vault_identity_group_alias", func(r *config.Resource) {
+		r.References = config.References{
+			"canonicalIdFromGroupRef": {
+				TerraformName: "vault_identity_group",
+				Extractor:     "github.com/upbound/upjet/pkg/resource.ExtractResourceID()",
+			},
+		}
 	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR adds option to reference the Group resource to get canonical id to create Group Alias.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
