### PR TITLE
Fix authentication configuration options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,11 @@ vault.uninstall:
 	@$(KUBECTL) delete secret vault-auto-unseal-keys --ignore-not-found
 	@$(OK) uninstalled vault
 
-.PHONY: uptest e2e cobertura submodules fallthrough run crds.clean vault.uninstall
+vault.token:
+	@$(KUBECTL) get secret -n vault vault-creds --template='{{ .data.credentials | base64decode }}' | jq -r '.token'
+
+.PHONY: uptest e2e cobertura submodules fallthrough run crds.clean 
+.PHONY: vault.uninstall vault.token
 
 # ====================================================================================
 # Special Targets

--- a/cluster/test/setup-auth.sh
+++ b/cluster/test/setup-auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VAULT_TOKEN=$(make vault.token)
+export VAULT_TOKEN
+
+# requires Vault to be port-forwarded
+VAULT_ADDR="http://127.0.0.1:8200"
+export VAULT_ADDR
+
+if vault auth list | grep -q "approle"; then
+    echo "Approle auth method already enabled"
+else
+    echo "Enabling approle auth method"
+    vault auth enable approle
+fi
+
+echo "Creating development admin policy"
+curl \
+  --request POST \
+  --header "X-Vault-Token: $VAULT_TOKEN" \
+  --data '{"policy": "path \"*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"] }"}' \
+  "$VAULT_ADDR/v1/sys/policy/dev-admin"
+
+echo "Creating AppRole role my-role"
+vault write auth/approle/role/my-role \
+    token_type=batch \
+    token_max_ttl=10m \
+    bind_secret_id=false \
+    secret_id_bound_cidrs="0.0.0.0/0" \
+    token_bound_cidrs="0.0.0.0/0" \
+    token_policies="dev-admin"
+
+vault write auth/approle/role/my-role/role-id \
+    role_id=my-role
+
+echo "Authentication set up!"

--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -96,6 +96,13 @@ metadata:
 type: Opaque
 stringData:
   credentials: '{"token": "$VAULT_ROOT_TOKEN"}'
+  appRoleCredentials: |
+    {
+      "auth_login": {
+        "path": "auth/approle/login",
+        "parameters": {"role_id": "my-role"}
+      }
+    }
 EOF
 
 echo_info "Applying providerconfig"
@@ -115,4 +122,20 @@ spec:
       namespace: vault
       name: vault-creds
       key: credentials
+EOF
+cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: vault.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: vault-provider-config-approle
+spec:
+  address: http://$VAULT_0_POD_IP:8200
+  skip_child_token: true
+  skip_tls_verify: true
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: vault
+      name: vault-creds
+      key: appRoleCredentials
 EOF


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #49 where authentication configuration options weren't propagated correctly, e.g.
```hcl
provider "vault" {
  auth_login {
    path = "auth/approle/login"

    parameters = {
      role_id = "my-role"
    }
  }
}
```
is mapped to Kubernetes Secret as:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: vault-creds
  namespace: vault
type: Opaque
stringData:
  approle-login: |
    {
      "auth_login": {
        "path": "auth/approle/login",
        "parameters": {"role_id": "my-role"}
      }
    }
```
but the contents of `approle-login` key needs to be internally passed to `terraform.Setup{}.Configuration["auth_login"]` as array of a single element, not as a map

see: https://registry.terraform.io/providers/hashicorp/vault/latest/docs#vault-authentication-configuration-options

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

1. `make local-deploy`
2. `make uptest UPTEST_EXAMPLE_LIST=xyz.yaml`
3. run `./cluster/test/setup-auth.sh` to generate AppRole auth and role (Vault must be port-forwarded to :8200)
4. run any uptest example with ProviderConfig reference changed to `vault-provider-config-approle`

[contribution process]: https://git.io/fj2m9
