### PR TITLE
add references for ca resources

### DIFF
--- a/apis/ad/v1alpha1/zz_secretbackend_types.go
+++ b/apis/ad/v1alpha1/zz_secretbackend_types.go
@@ -117,7 +117,7 @@ type SecretBackendInitParameters struct {
 	// Target namespace. (requires Enterprise)
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Name of the password policy to use to generate passwords.
+	// 1.11+
 	// Name of the password policy to use to generate passwords.
 	PasswordPolicy *string `json:"passwordPolicy,omitempty" tf:"password_policy,omitempty"`
 
@@ -270,7 +270,7 @@ type SecretBackendObservation struct {
 	// Target namespace. (requires Enterprise)
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Name of the password policy to use to generate passwords.
+	// 1.11+
 	// Name of the password policy to use to generate passwords.
 	PasswordPolicy *string `json:"passwordPolicy,omitempty" tf:"password_policy,omitempty"`
 
@@ -455,7 +455,7 @@ type SecretBackendParameters struct {
 	// +kubebuilder:validation:Optional
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Name of the password policy to use to generate passwords.
+	// 1.11+
 	// Name of the password policy to use to generate passwords.
 	// +kubebuilder:validation:Optional
 	PasswordPolicy *string `json:"passwordPolicy,omitempty" tf:"password_policy,omitempty"`

--- a/apis/aws/v1alpha1/zz_authbackendclient_types.go
+++ b/apis/aws/v1alpha1/zz_authbackendclient_types.go
@@ -16,7 +16,7 @@ import (
 type AuthBackendClientInitParameters struct {
 
 	// The AWS access key that Vault should use for the
-	// auth backend. Mutually exclusive with identity_token_audience.
+	// auth backend.
 	// AWS Access key with permissions to query AWS APIs.
 	AccessKeySecretRef *v1.SecretKeySelector `json:"accessKeySecretRef,omitempty" tf:"-"`
 
@@ -51,18 +51,12 @@ type AuthBackendClientInitParameters struct {
 	// The value to require in the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity requests that are used in the iam auth method.
 	IAMServerIDHeaderValue *string `json:"iamServerIdHeaderValue,omitempty" tf:"iam_server_id_header_value,omitempty"`
 
-	// The audience claim value. Mutually exclusive with access_key.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
-	// Number of max retries the client should use for recoverable errors.
-	// The default -1 falls back to the AWS SDK's default behavior.
 	// Number of max retries the client should use for recoverable errors.
 	MaxRetries *float64 `json:"maxRetries,omitempty" tf:"max_retries,omitempty"`
 
@@ -73,8 +67,6 @@ type AuthBackendClientInitParameters struct {
 	// Target namespace. (requires Enterprise)
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// Role ARN to assume for plugin identity token federation.
 	RoleArn *string `json:"roleArn,omitempty" tf:"role_arn,omitempty"`
 
@@ -127,18 +119,12 @@ type AuthBackendClientObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// The audience claim value. Mutually exclusive with access_key.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
-	// Number of max retries the client should use for recoverable errors.
-	// The default -1 falls back to the AWS SDK's default behavior.
 	// Number of max retries the client should use for recoverable errors.
 	MaxRetries *float64 `json:"maxRetries,omitempty" tf:"max_retries,omitempty"`
 
@@ -149,8 +135,6 @@ type AuthBackendClientObservation struct {
 	// Target namespace. (requires Enterprise)
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// Role ARN to assume for plugin identity token federation.
 	RoleArn *string `json:"roleArn,omitempty" tf:"role_arn,omitempty"`
 
@@ -176,7 +160,7 @@ type AuthBackendClientObservation struct {
 type AuthBackendClientParameters struct {
 
 	// The AWS access key that Vault should use for the
-	// auth backend. Mutually exclusive with identity_token_audience.
+	// auth backend.
 	// AWS Access key with permissions to query AWS APIs.
 	// +kubebuilder:validation:Optional
 	AccessKeySecretRef *v1.SecretKeySelector `json:"accessKeySecretRef,omitempty" tf:"-"`
@@ -216,20 +200,14 @@ type AuthBackendClientParameters struct {
 	// +kubebuilder:validation:Optional
 	IAMServerIDHeaderValue *string `json:"iamServerIdHeaderValue,omitempty" tf:"iam_server_id_header_value,omitempty"`
 
-	// The audience claim value. Mutually exclusive with access_key.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The audience claim value.
 	// +kubebuilder:validation:Optional
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	// +kubebuilder:validation:Optional
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
-	// Number of max retries the client should use for recoverable errors.
-	// The default -1 falls back to the AWS SDK's default behavior.
 	// Number of max retries the client should use for recoverable errors.
 	// +kubebuilder:validation:Optional
 	MaxRetries *float64 `json:"maxRetries,omitempty" tf:"max_retries,omitempty"`
@@ -242,8 +220,6 @@ type AuthBackendClientParameters struct {
 	// +kubebuilder:validation:Optional
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
-	// Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// Role ARN to assume for plugin identity token federation.
 	// +kubebuilder:validation:Optional
 	RoleArn *string `json:"roleArn,omitempty" tf:"role_arn,omitempty"`

--- a/apis/aws/v1alpha1/zz_secretbackendrole_types.go
+++ b/apis/aws/v1alpha1/zz_secretbackendrole_types.go
@@ -45,8 +45,6 @@ type SecretBackendRoleInitParameters struct {
 	DefaultStsTTL *float64 `json:"defaultStsTtl,omitempty" tf:"default_sts_ttl,omitempty"`
 
 	// External ID to set for assume role creds.
-	// Valid only when credential_type is set to assumed_role.
-	// External ID to set for assume role creds.
 	ExternalID *string `json:"externalId,omitempty" tf:"external_id,omitempty"`
 
 	// A list of IAM group names. IAM users generated
@@ -59,8 +57,6 @@ type SecretBackendRoleInitParameters struct {
 	// +listType=set
 	IAMGroups []*string `json:"iamGroups,omitempty" tf:"iam_groups,omitempty"`
 
-	// A map of strings representing key/value pairs
-	// to be used as tags for any IAM user that is created by this role.
 	// A map of strings representing key/value pairs used as tags for any IAM user created by this role.
 	// +mapType=granular
 	IAMTags map[string]*string `json:"iamTags,omitempty" tf:"iam_tags,omitempty"`
@@ -116,9 +112,6 @@ type SecretBackendRoleInitParameters struct {
 	// +listType=set
 	RoleArns []*string `json:"roleArns,omitempty" tf:"role_arns,omitempty"`
 
-	// A map of strings representing key/value pairs to be set
-	// during assume role creds creation. Valid only when credential_type is set to
-	// assumed_role.
 	// Session tags to be set for assume role creds created.
 	// +mapType=granular
 	SessionTags map[string]*string `json:"sessionTags,omitempty" tf:"session_tags,omitempty"`
@@ -151,8 +144,6 @@ type SecretBackendRoleObservation struct {
 	DefaultStsTTL *float64 `json:"defaultStsTtl,omitempty" tf:"default_sts_ttl,omitempty"`
 
 	// External ID to set for assume role creds.
-	// Valid only when credential_type is set to assumed_role.
-	// External ID to set for assume role creds.
 	ExternalID *string `json:"externalId,omitempty" tf:"external_id,omitempty"`
 
 	// A list of IAM group names. IAM users generated
@@ -165,8 +156,6 @@ type SecretBackendRoleObservation struct {
 	// +listType=set
 	IAMGroups []*string `json:"iamGroups,omitempty" tf:"iam_groups,omitempty"`
 
-	// A map of strings representing key/value pairs
-	// to be used as tags for any IAM user that is created by this role.
 	// A map of strings representing key/value pairs used as tags for any IAM user created by this role.
 	// +mapType=granular
 	IAMTags map[string]*string `json:"iamTags,omitempty" tf:"iam_tags,omitempty"`
@@ -224,9 +213,6 @@ type SecretBackendRoleObservation struct {
 	// +listType=set
 	RoleArns []*string `json:"roleArns,omitempty" tf:"role_arns,omitempty"`
 
-	// A map of strings representing key/value pairs to be set
-	// during assume role creds creation. Valid only when credential_type is set to
-	// assumed_role.
 	// Session tags to be set for assume role creds created.
 	// +mapType=granular
 	SessionTags map[string]*string `json:"sessionTags,omitempty" tf:"session_tags,omitempty"`
@@ -272,8 +258,6 @@ type SecretBackendRoleParameters struct {
 	DefaultStsTTL *float64 `json:"defaultStsTtl,omitempty" tf:"default_sts_ttl,omitempty"`
 
 	// External ID to set for assume role creds.
-	// Valid only when credential_type is set to assumed_role.
-	// External ID to set for assume role creds.
 	// +kubebuilder:validation:Optional
 	ExternalID *string `json:"externalId,omitempty" tf:"external_id,omitempty"`
 
@@ -288,8 +272,6 @@ type SecretBackendRoleParameters struct {
 	// +listType=set
 	IAMGroups []*string `json:"iamGroups,omitempty" tf:"iam_groups,omitempty"`
 
-	// A map of strings representing key/value pairs
-	// to be used as tags for any IAM user that is created by this role.
 	// A map of strings representing key/value pairs used as tags for any IAM user created by this role.
 	// +kubebuilder:validation:Optional
 	// +mapType=granular
@@ -353,9 +335,6 @@ type SecretBackendRoleParameters struct {
 	// +listType=set
 	RoleArns []*string `json:"roleArns,omitempty" tf:"role_arns,omitempty"`
 
-	// A map of strings representing key/value pairs to be set
-	// during assume role creds creation. Valid only when credential_type is set to
-	// assumed_role.
 	// Session tags to be set for assume role creds created.
 	// +kubebuilder:validation:Optional
 	// +mapType=granular

--- a/apis/azure/v1alpha1/zz_authbackendconfig_types.go
+++ b/apis/azure/v1alpha1/zz_authbackendconfig_types.go
@@ -46,14 +46,9 @@ type AuthBackendConfigInitParameters struct {
 	// The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
 	Environment *string `json:"environment,omitempty" tf:"environment,omitempty"`
 
-	// The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds.
-	// Defaults to 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -90,14 +85,9 @@ type AuthBackendConfigObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds.
-	// Defaults to 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -151,15 +141,10 @@ type AuthBackendConfigParameters struct {
 	// +kubebuilder:validation:Optional
 	Environment *string `json:"environment,omitempty" tf:"environment,omitempty"`
 
-	// The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	// +kubebuilder:validation:Optional
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The TTL of generated identity tokens in seconds.
-	// Defaults to 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	// +kubebuilder:validation:Optional
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`

--- a/apis/azure/v1alpha1/zz_secretbackend_types.go
+++ b/apis/azure/v1alpha1/zz_secretbackend_types.go
@@ -35,18 +35,12 @@ type SecretBackendInitParameters struct {
 	// The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
 	Environment *string `json:"environment,omitempty" tf:"environment,omitempty"`
 
-	// The audience claim value. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The key to use for signing identity tokens.
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -92,18 +86,12 @@ type SecretBackendObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// The audience claim value. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The key to use for signing identity tokens.
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -152,20 +140,14 @@ type SecretBackendParameters struct {
 	// +kubebuilder:validation:Optional
 	Environment *string `json:"environment,omitempty" tf:"environment,omitempty"`
 
-	// The audience claim value. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The audience claim value.
 	// +kubebuilder:validation:Optional
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing identity tokens. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The key to use for signing identity tokens.
 	// +kubebuilder:validation:Optional
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-	// Available only for Vault Enterprise
 	// The TTL of generated identity tokens in seconds.
 	// +kubebuilder:validation:Optional
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`

--- a/apis/gcp/v1alpha1/zz_secretbackend_types.go
+++ b/apis/gcp/v1alpha1/zz_secretbackend_types.go
@@ -33,20 +33,12 @@ type SecretBackendInitParameters struct {
 	// If set, opts out of mount migration on path updates.
 	DisableRemount *bool `json:"disableRemount,omitempty" tf:"disable_remount,omitempty"`
 
-	// The audience claim value for plugin identity
-	// tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-	// Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The audience claim value for plugin identity tokens.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing plugin identity
-	// tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The key to use for signing identity tokens.
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated tokens. Defaults to
-	// 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The TTL of generated tokens.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -71,15 +63,12 @@ type SecretBackendInitParameters struct {
 	// Path to mount the backend at.
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// –  Service Account to impersonate for plugin workload identity federation.
-	// Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// Service Account to impersonate for plugin workload identity federation.
 	ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty" tf:"service_account_email,omitempty"`
 }
 
 type SecretBackendObservation struct {
 
-	// The accessor of the created GCP mount.
 	// Accessor of the created GCP mount.
 	Accessor *string `json:"accessor,omitempty" tf:"accessor,omitempty"`
 
@@ -99,20 +88,12 @@ type SecretBackendObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// The audience claim value for plugin identity
-	// tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-	// Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The audience claim value for plugin identity tokens.
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing plugin identity
-	// tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The key to use for signing identity tokens.
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated tokens. Defaults to
-	// 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The TTL of generated tokens.
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
 
@@ -137,8 +118,6 @@ type SecretBackendObservation struct {
 	// Path to mount the backend at.
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// –  Service Account to impersonate for plugin workload identity federation.
-	// Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// Service Account to impersonate for plugin workload identity federation.
 	ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty" tf:"service_account_email,omitempty"`
 }
@@ -167,22 +146,14 @@ type SecretBackendParameters struct {
 	// +kubebuilder:validation:Optional
 	DisableRemount *bool `json:"disableRemount,omitempty" tf:"disable_remount,omitempty"`
 
-	// The audience claim value for plugin identity
-	// tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-	// Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The audience claim value for plugin identity tokens.
 	// +kubebuilder:validation:Optional
 	IdentityTokenAudience *string `json:"identityTokenAudience,omitempty" tf:"identity_token_audience,omitempty"`
 
-	// The key to use for signing plugin identity
-	// tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The key to use for signing identity tokens.
 	// +kubebuilder:validation:Optional
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// The TTL of generated tokens. Defaults to
-	// 1 hour. Uses duration format strings.
-	// Requires Vault 1.17+. Available only for Vault Enterprise.
 	// The TTL of generated tokens.
 	// +kubebuilder:validation:Optional
 	IdentityTokenTTL *float64 `json:"identityTokenTtl,omitempty" tf:"identity_token_ttl,omitempty"`
@@ -212,8 +183,6 @@ type SecretBackendParameters struct {
 	// +kubebuilder:validation:Optional
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// –  Service Account to impersonate for plugin workload identity federation.
-	// Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
 	// Service Account to impersonate for plugin workload identity federation.
 	// +kubebuilder:validation:Optional
 	ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty" tf:"service_account_email,omitempty"`

--- a/apis/identity/v1alpha1/zz_oidcclient_types.go
+++ b/apis/identity/v1alpha1/zz_oidcclient_types.go
@@ -70,7 +70,6 @@ type OidcClientObservation struct {
 	// +listType=set
 	Assignments []*string `json:"assignments,omitempty" tf:"assignments,omitempty"`
 
-	// The Client ID returned by Vault.
 	// The Client ID from Vault.
 	ClientID *string `json:"clientId,omitempty" tf:"client_id,omitempty"`
 

--- a/apis/jwt/v1alpha1/zz_authbackendrole_types.go
+++ b/apis/jwt/v1alpha1/zz_authbackendrole_types.go
@@ -36,7 +36,9 @@ type AuthBackendRoleInitParameters struct {
 	// +kubebuilder:validation:Optional
 	BackendSelector *v1.Selector `json:"backendSelector,omitempty" tf:"-"`
 
-	// List of aud claims to match against. Any match is sufficient.
+	// (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+	// or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+	// Any match is sufficient.
 	// List of aud claims to match against. Any match is sufficient.
 	// +listType=set
 	BoundAudiences []*string `json:"boundAudiences,omitempty" tf:"bound_audiences,omitempty"`
@@ -75,7 +77,7 @@ type AuthBackendRoleInitParameters struct {
 	DisableBoundClaimsParsing *bool `json:"disableBoundClaimsParsing,omitempty" tf:"disable_bound_claims_parsing,omitempty"`
 
 	// The amount of leeway to add to expiration (exp) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	ExpirationLeeway *float64 `json:"expirationLeeway,omitempty" tf:"expiration_leeway,omitempty"`
@@ -100,7 +102,7 @@ type AuthBackendRoleInitParameters struct {
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
 	// The amount of leeway to add to not before (nbf) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	NotBeforeLeeway *float64 `json:"notBeforeLeeway,omitempty" tf:"not_before_leeway,omitempty"`
@@ -207,7 +209,9 @@ type AuthBackendRoleObservation struct {
 	// Unique name of the auth backend to configure.
 	Backend *string `json:"backend,omitempty" tf:"backend,omitempty"`
 
-	// List of aud claims to match against. Any match is sufficient.
+	// (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+	// or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+	// Any match is sufficient.
 	// List of aud claims to match against. Any match is sufficient.
 	// +listType=set
 	BoundAudiences []*string `json:"boundAudiences,omitempty" tf:"bound_audiences,omitempty"`
@@ -246,7 +250,7 @@ type AuthBackendRoleObservation struct {
 	DisableBoundClaimsParsing *bool `json:"disableBoundClaimsParsing,omitempty" tf:"disable_bound_claims_parsing,omitempty"`
 
 	// The amount of leeway to add to expiration (exp) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	ExpirationLeeway *float64 `json:"expirationLeeway,omitempty" tf:"expiration_leeway,omitempty"`
@@ -273,7 +277,7 @@ type AuthBackendRoleObservation struct {
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
 	// The amount of leeway to add to not before (nbf) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	NotBeforeLeeway *float64 `json:"notBeforeLeeway,omitempty" tf:"not_before_leeway,omitempty"`
@@ -392,7 +396,9 @@ type AuthBackendRoleParameters struct {
 	// +kubebuilder:validation:Optional
 	BackendSelector *v1.Selector `json:"backendSelector,omitempty" tf:"-"`
 
-	// List of aud claims to match against. Any match is sufficient.
+	// (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+	// or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+	// Any match is sufficient.
 	// List of aud claims to match against. Any match is sufficient.
 	// +kubebuilder:validation:Optional
 	// +listType=set
@@ -438,7 +444,7 @@ type AuthBackendRoleParameters struct {
 	DisableBoundClaimsParsing *bool `json:"disableBoundClaimsParsing,omitempty" tf:"disable_bound_claims_parsing,omitempty"`
 
 	// The amount of leeway to add to expiration (exp) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	// +kubebuilder:validation:Optional
@@ -467,7 +473,7 @@ type AuthBackendRoleParameters struct {
 	Namespace *string `json:"namespace,omitempty" tf:"namespace,omitempty"`
 
 	// The amount of leeway to add to not before (nbf) claims to account for
-	// clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+	// clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
 	// Only applicable with "jwt" roles.
 	// The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
 	// +kubebuilder:validation:Optional

--- a/apis/kubernetes/v1alpha1/zz_secretbackendrole_types.go
+++ b/apis/kubernetes/v1alpha1/zz_secretbackendrole_types.go
@@ -15,16 +15,11 @@ import (
 
 type SecretBackendRoleInitParameters struct {
 
-	// A label selector for Kubernetes namespaces
-	// in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-	// of type LabelSelector.
-	// If set with allowed_kubernetes_namespace, the conditions are ORed.
 	// A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
 	AllowedKubernetesNamespaceSelector *string `json:"allowedKubernetesNamespaceSelector,omitempty" tf:"allowed_kubernetes_namespace_selector,omitempty"`
 
 	// The list of Kubernetes namespaces this role
-	// can generate credentials for. If set to * all namespaces are allowed. If set with
-	// allowed_kubernetes_namespace_selector, the conditions are ORed.
+	// can generate credentials for. If set to * all namespaces are allowed.
 	// The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
 	AllowedKubernetesNamespaces []*string `json:"allowedKubernetesNamespaces,omitempty" tf:"allowed_kubernetes_namespaces,omitempty"`
 
@@ -107,16 +102,11 @@ type SecretBackendRoleInitParameters struct {
 
 type SecretBackendRoleObservation struct {
 
-	// A label selector for Kubernetes namespaces
-	// in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-	// of type LabelSelector.
-	// If set with allowed_kubernetes_namespace, the conditions are ORed.
 	// A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
 	AllowedKubernetesNamespaceSelector *string `json:"allowedKubernetesNamespaceSelector,omitempty" tf:"allowed_kubernetes_namespace_selector,omitempty"`
 
 	// The list of Kubernetes namespaces this role
-	// can generate credentials for. If set to * all namespaces are allowed. If set with
-	// allowed_kubernetes_namespace_selector, the conditions are ORed.
+	// can generate credentials for. If set to * all namespaces are allowed.
 	// The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
 	AllowedKubernetesNamespaces []*string `json:"allowedKubernetesNamespaces,omitempty" tf:"allowed_kubernetes_namespaces,omitempty"`
 
@@ -191,17 +181,12 @@ type SecretBackendRoleObservation struct {
 
 type SecretBackendRoleParameters struct {
 
-	// A label selector for Kubernetes namespaces
-	// in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-	// of type LabelSelector.
-	// If set with allowed_kubernetes_namespace, the conditions are ORed.
 	// A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
 	// +kubebuilder:validation:Optional
 	AllowedKubernetesNamespaceSelector *string `json:"allowedKubernetesNamespaceSelector,omitempty" tf:"allowed_kubernetes_namespace_selector,omitempty"`
 
 	// The list of Kubernetes namespaces this role
-	// can generate credentials for. If set to * all namespaces are allowed. If set with
-	// allowed_kubernetes_namespace_selector, the conditions are ORed.
+	// can generate credentials for. If set to * all namespaces are allowed.
 	// The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
 	// +kubebuilder:validation:Optional
 	AllowedKubernetesNamespaces []*string `json:"allowedKubernetesNamespaces,omitempty" tf:"allowed_kubernetes_namespaces,omitempty"`

--- a/apis/mongodbatlas/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mongodbatlas/v1alpha1/zz_generated.deepcopy.go
@@ -48,16 +48,6 @@ func (in *SecretBackendInitParameters) DeepCopyInto(out *SecretBackendInitParame
 		*out = new(string)
 		**out = **in
 	}
-	if in.MountRef != nil {
-		in, out := &in.MountRef, &out.MountRef
-		*out = new(v1.Reference)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.MountSelector != nil {
-		in, out := &in.MountSelector, &out.MountSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
 		*out = new(string)
@@ -169,16 +159,6 @@ func (in *SecretBackendParameters) DeepCopyInto(out *SecretBackendParameters) {
 		in, out := &in.Mount, &out.Mount
 		*out = new(string)
 		**out = **in
-	}
-	if in.MountRef != nil {
-		in, out := &in.MountRef, &out.MountRef
-		*out = new(v1.Reference)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.MountSelector != nil {
-		in, out := &in.MountSelector, &out.MountSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace

--- a/apis/mongodbatlas/v1alpha1/zz_generated.resolvers.go
+++ b/apis/mongodbatlas/v1alpha1/zz_generated.resolvers.go
@@ -14,48 +14,6 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ResolveReferences of this SecretBackend.
-func (mg *SecretBackend) ResolveReferences(ctx context.Context, c client.Reader) error {
-	r := reference.NewAPIResolver(c, mg)
-
-	var rsp reference.ResolutionResponse
-	var err error
-
-	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Mount),
-		Extract:      resource.ExtractParamPath("path", false),
-		Reference:    mg.Spec.ForProvider.MountRef,
-		Selector:     mg.Spec.ForProvider.MountSelector,
-		To: reference.To{
-			List:    &v1alpha1.MountList{},
-			Managed: &v1alpha1.Mount{},
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "mg.Spec.ForProvider.Mount")
-	}
-	mg.Spec.ForProvider.Mount = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.MountRef = rsp.ResolvedReference
-
-	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.Mount),
-		Extract:      resource.ExtractParamPath("path", false),
-		Reference:    mg.Spec.InitProvider.MountRef,
-		Selector:     mg.Spec.InitProvider.MountSelector,
-		To: reference.To{
-			List:    &v1alpha1.MountList{},
-			Managed: &v1alpha1.Mount{},
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "mg.Spec.InitProvider.Mount")
-	}
-	mg.Spec.InitProvider.Mount = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.InitProvider.MountRef = rsp.ResolvedReference
-
-	return nil
-}
-
 // ResolveReferences of this SecretRole.
 func (mg *SecretRole) ResolveReferences(ctx context.Context, c client.Reader) error {
 	r := reference.NewAPIResolver(c, mg)

--- a/apis/mongodbatlas/v1alpha1/zz_secretbackend_types.go
+++ b/apis/mongodbatlas/v1alpha1/zz_secretbackend_types.go
@@ -17,17 +17,7 @@ type SecretBackendInitParameters struct {
 
 	// Path where the MongoDB Atlas Secrets Engine is mounted.
 	// Path where MongoDB Atlas secret backend is mounted
-	// +crossplane:generate:reference:type=github.com/upbound/provider-vault/apis/vault/v1alpha1.Mount
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("path",false)
 	Mount *string `json:"mount,omitempty" tf:"mount,omitempty"`
-
-	// Reference to a Mount in vault to populate mount.
-	// +kubebuilder:validation:Optional
-	MountRef *v1.Reference `json:"mountRef,omitempty" tf:"-"`
-
-	// Selector for a Mount in vault to populate mount.
-	// +kubebuilder:validation:Optional
-	MountSelector *v1.Selector `json:"mountSelector,omitempty" tf:"-"`
 
 	// The namespace to provision the resource in.
 	// The value should not contain leading or trailing forward slashes.
@@ -75,18 +65,8 @@ type SecretBackendParameters struct {
 
 	// Path where the MongoDB Atlas Secrets Engine is mounted.
 	// Path where MongoDB Atlas secret backend is mounted
-	// +crossplane:generate:reference:type=github.com/upbound/provider-vault/apis/vault/v1alpha1.Mount
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("path",false)
 	// +kubebuilder:validation:Optional
 	Mount *string `json:"mount,omitempty" tf:"mount,omitempty"`
-
-	// Reference to a Mount in vault to populate mount.
-	// +kubebuilder:validation:Optional
-	MountRef *v1.Reference `json:"mountRef,omitempty" tf:"-"`
-
-	// Selector for a Mount in vault to populate mount.
-	// +kubebuilder:validation:Optional
-	MountSelector *v1.Selector `json:"mountSelector,omitempty" tf:"-"`
 
 	// The namespace to provision the resource in.
 	// The value should not contain leading or trailing forward slashes.
@@ -143,6 +123,7 @@ type SecretBackendStatus struct {
 type SecretBackend struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.mount) || (has(self.initProvider) && has(self.initProvider.mount))",message="spec.forProvider.mount is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.privateKey) || (has(self.initProvider) && has(self.initProvider.privateKey))",message="spec.forProvider.privateKey is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.publicKey) || (has(self.initProvider) && has(self.initProvider.publicKey))",message="spec.forProvider.publicKey is a required parameter"
 	Spec   SecretBackendSpec   `json:"spec"`

--- a/apis/mongodbatlas/v1alpha1/zz_secretrole_types.go
+++ b/apis/mongodbatlas/v1alpha1/zz_secretrole_types.go
@@ -62,11 +62,11 @@ type SecretRoleInitParameters struct {
 	// ID for the project to which the target API Key belongs
 	ProjectID *string `json:"projectId,omitempty" tf:"project_id,omitempty"`
 
-	// Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+	// Roles assigned when an org API key is assigned to a project API key.
 	// Roles assigned when an org API key is assigned to a project API key
 	ProjectRoles []*string `json:"projectRoles,omitempty" tf:"project_roles,omitempty"`
 
-	// List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+	// List of roles that the API Key needs to have.
 	// List of roles that the API Key needs to have
 	Roles []*string `json:"roles,omitempty" tf:"roles,omitempty"`
 
@@ -116,11 +116,11 @@ type SecretRoleObservation struct {
 	// ID for the project to which the target API Key belongs
 	ProjectID *string `json:"projectId,omitempty" tf:"project_id,omitempty"`
 
-	// Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+	// Roles assigned when an org API key is assigned to a project API key.
 	// Roles assigned when an org API key is assigned to a project API key
 	ProjectRoles []*string `json:"projectRoles,omitempty" tf:"project_roles,omitempty"`
 
-	// List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+	// List of roles that the API Key needs to have.
 	// List of roles that the API Key needs to have
 	Roles []*string `json:"roles,omitempty" tf:"roles,omitempty"`
 
@@ -186,12 +186,12 @@ type SecretRoleParameters struct {
 	// +kubebuilder:validation:Optional
 	ProjectID *string `json:"projectId,omitempty" tf:"project_id,omitempty"`
 
-	// Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+	// Roles assigned when an org API key is assigned to a project API key.
 	// Roles assigned when an org API key is assigned to a project API key
 	// +kubebuilder:validation:Optional
 	ProjectRoles []*string `json:"projectRoles,omitempty" tf:"project_roles,omitempty"`
 
-	// List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+	// List of roles that the API Key needs to have.
 	// List of roles that the API Key needs to have
 	// +kubebuilder:validation:Optional
 	Roles []*string `json:"roles,omitempty" tf:"roles,omitempty"`

--- a/apis/pki/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/pki/v1alpha1/zz_generated.deepcopy.go
@@ -4315,6 +4315,16 @@ func (in *SecretBackendRootSignIntermediateInitParameters) DeepCopyInto(out *Sec
 		*out = new(string)
 		**out = **in
 	}
+	if in.CsrRef != nil {
+		in, out := &in.CsrRef, &out.CsrRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CsrSelector != nil {
+		in, out := &in.CsrSelector, &out.CsrSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ExcludeCnFromSans != nil {
 		in, out := &in.ExcludeCnFromSans, &out.ExcludeCnFromSans
 		*out = new(bool)
@@ -4702,6 +4712,16 @@ func (in *SecretBackendRootSignIntermediateParameters) DeepCopyInto(out *SecretB
 		in, out := &in.Csr, &out.Csr
 		*out = new(string)
 		**out = **in
+	}
+	if in.CsrRef != nil {
+		in, out := &in.CsrRef, &out.CsrRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CsrSelector != nil {
+		in, out := &in.CsrSelector, &out.CsrSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ExcludeCnFromSans != nil {
 		in, out := &in.ExcludeCnFromSans, &out.ExcludeCnFromSans

--- a/apis/pki/v1alpha1/zz_secretbackendconfigurls_types.go
+++ b/apis/pki/v1alpha1/zz_secretbackendconfigurls_types.go
@@ -34,7 +34,6 @@ type SecretBackendConfigUrlsInitParameters struct {
 	CrlDistributionPoints []*string `json:"crlDistributionPoints,omitempty" tf:"crl_distribution_points,omitempty"`
 
 	// Specifies that templating of AIA fields is allowed.
-	// Specifies that templating of AIA fields is allowed.
 	EnableTemplating *bool `json:"enableTemplating,omitempty" tf:"enable_templating,omitempty"`
 
 	// Specifies the URL values for the Issuing Certificate field.
@@ -63,7 +62,6 @@ type SecretBackendConfigUrlsObservation struct {
 	// Specifies the URL values for the CRL Distribution Points field.
 	CrlDistributionPoints []*string `json:"crlDistributionPoints,omitempty" tf:"crl_distribution_points,omitempty"`
 
-	// Specifies that templating of AIA fields is allowed.
 	// Specifies that templating of AIA fields is allowed.
 	EnableTemplating *bool `json:"enableTemplating,omitempty" tf:"enable_templating,omitempty"`
 
@@ -107,7 +105,6 @@ type SecretBackendConfigUrlsParameters struct {
 	// +kubebuilder:validation:Optional
 	CrlDistributionPoints []*string `json:"crlDistributionPoints,omitempty" tf:"crl_distribution_points,omitempty"`
 
-	// Specifies that templating of AIA fields is allowed.
 	// Specifies that templating of AIA fields is allowed.
 	// +kubebuilder:validation:Optional
 	EnableTemplating *bool `json:"enableTemplating,omitempty" tf:"enable_templating,omitempty"`

--- a/apis/pki/v1alpha1/zz_secretbackendintermediatesetsigned_types.go
+++ b/apis/pki/v1alpha1/zz_secretbackendintermediatesetsigned_types.go
@@ -33,15 +33,15 @@ type SecretBackendIntermediateSetSignedInitParameters struct {
 	// CA certificates to populate the whole chain, which will then enable returning the full chain from
 	// issue and sign operations.
 	// The certificate.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-vault/apis/pki/v1alpha1.SecretBackendRootSignIntermediate
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("certificate",true)
+	// +crossplane:generate:reference:type=SecretBackendRootSignIntermediate
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-vault/config/common.ExtractCrt()
 	Certificate *string `json:"certificate,omitempty" tf:"certificate,omitempty"`
 
-	// Reference to a SecretBackendRootSignIntermediate in pki to populate certificate.
+	// Reference to a SecretBackendRootSignIntermediate to populate certificate.
 	// +kubebuilder:validation:Optional
 	CertificateRef *v1.Reference `json:"certificateRef,omitempty" tf:"-"`
 
-	// Selector for a SecretBackendRootSignIntermediate in pki to populate certificate.
+	// Selector for a SecretBackendRootSignIntermediate to populate certificate.
 	// +kubebuilder:validation:Optional
 	CertificateSelector *v1.Selector `json:"certificateSelector,omitempty" tf:"-"`
 
@@ -105,16 +105,16 @@ type SecretBackendIntermediateSetSignedParameters struct {
 	// CA certificates to populate the whole chain, which will then enable returning the full chain from
 	// issue and sign operations.
 	// The certificate.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-vault/apis/pki/v1alpha1.SecretBackendRootSignIntermediate
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("certificate",true)
+	// +crossplane:generate:reference:type=SecretBackendRootSignIntermediate
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-vault/config/common.ExtractCrt()
 	// +kubebuilder:validation:Optional
 	Certificate *string `json:"certificate,omitempty" tf:"certificate,omitempty"`
 
-	// Reference to a SecretBackendRootSignIntermediate in pki to populate certificate.
+	// Reference to a SecretBackendRootSignIntermediate to populate certificate.
 	// +kubebuilder:validation:Optional
 	CertificateRef *v1.Reference `json:"certificateRef,omitempty" tf:"-"`
 
-	// Selector for a SecretBackendRootSignIntermediate in pki to populate certificate.
+	// Selector for a SecretBackendRootSignIntermediate to populate certificate.
 	// +kubebuilder:validation:Optional
 	CertificateSelector *v1.Selector `json:"certificateSelector,omitempty" tf:"-"`
 

--- a/apis/pki/v1alpha1/zz_secretbackendrootsignintermediate_types.go
+++ b/apis/pki/v1alpha1/zz_secretbackendrootsignintermediate_types.go
@@ -28,7 +28,17 @@ type SecretBackendRootSignIntermediateInitParameters struct {
 	Country *string `json:"country,omitempty" tf:"country,omitempty"`
 
 	// The CSR.
+	// +crossplane:generate:reference:type=SecretBackendIntermediateCertRequest
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-vault/config/common.ExtractCsr()
 	Csr *string `json:"csr,omitempty" tf:"csr,omitempty"`
+
+	// Reference to a SecretBackendIntermediateCertRequest to populate csr.
+	// +kubebuilder:validation:Optional
+	CsrRef *v1.Reference `json:"csrRef,omitempty" tf:"-"`
+
+	// Selector for a SecretBackendIntermediateCertRequest to populate csr.
+	// +kubebuilder:validation:Optional
+	CsrSelector *v1.Selector `json:"csrSelector,omitempty" tf:"-"`
 
 	// Flag to exclude CN from SANs.
 	ExcludeCnFromSans *bool `json:"excludeCnFromSans,omitempty" tf:"exclude_cn_from_sans,omitempty"`
@@ -193,8 +203,18 @@ type SecretBackendRootSignIntermediateParameters struct {
 	Country *string `json:"country,omitempty" tf:"country,omitempty"`
 
 	// The CSR.
+	// +crossplane:generate:reference:type=SecretBackendIntermediateCertRequest
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-vault/config/common.ExtractCsr()
 	// +kubebuilder:validation:Optional
 	Csr *string `json:"csr,omitempty" tf:"csr,omitempty"`
+
+	// Reference to a SecretBackendIntermediateCertRequest to populate csr.
+	// +kubebuilder:validation:Optional
+	CsrRef *v1.Reference `json:"csrRef,omitempty" tf:"-"`
+
+	// Selector for a SecretBackendIntermediateCertRequest to populate csr.
+	// +kubebuilder:validation:Optional
+	CsrSelector *v1.Selector `json:"csrSelector,omitempty" tf:"-"`
 
 	// Flag to exclude CN from SANs.
 	// +kubebuilder:validation:Optional
@@ -307,7 +327,6 @@ type SecretBackendRootSignIntermediate struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.backend) || (has(self.initProvider) && has(self.initProvider.backend))",message="spec.forProvider.backend is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.commonName) || (has(self.initProvider) && has(self.initProvider.commonName))",message="spec.forProvider.commonName is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.csr) || (has(self.initProvider) && has(self.initProvider.csr))",message="spec.forProvider.csr is a required parameter"
 	Spec   SecretBackendRootSignIntermediateSpec   `json:"spec"`
 	Status SecretBackendRootSignIntermediateStatus `json:"status,omitempty"`
 }

--- a/apis/quota/v1alpha1/zz_leasecount_types.go
+++ b/apis/quota/v1alpha1/zz_leasecount_types.go
@@ -15,7 +15,6 @@ import (
 
 type LeaseCountInitParameters struct {
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`
 
@@ -52,7 +51,6 @@ type LeaseCountInitParameters struct {
 type LeaseCountObservation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`
 
@@ -88,7 +86,6 @@ type LeaseCountObservation struct {
 
 type LeaseCountParameters struct {
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	// +kubebuilder:validation:Optional
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`

--- a/apis/quota/v1alpha1/zz_ratelimit_types.go
+++ b/apis/quota/v1alpha1/zz_ratelimit_types.go
@@ -20,7 +20,6 @@ type RateLimitInitParameters struct {
 	// If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
 	BlockInterval *float64 `json:"blockInterval,omitempty" tf:"block_interval,omitempty"`
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`
 
@@ -67,7 +66,6 @@ type RateLimitObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`
 
@@ -113,7 +111,6 @@ type RateLimitParameters struct {
 	// +kubebuilder:validation:Optional
 	BlockInterval *float64 `json:"blockInterval,omitempty" tf:"block_interval,omitempty"`
 
-	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 	// If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
 	// +kubebuilder:validation:Optional
 	Inheritable *bool `json:"inheritable,omitempty" tf:"inheritable,omitempty"`

--- a/apis/ssh/v1alpha1/zz_secretbackendca_types.go
+++ b/apis/ssh/v1alpha1/zz_secretbackendca_types.go
@@ -33,11 +33,9 @@ type SecretBackendCAInitParameters struct {
 	// Whether Vault should generate the signing key pair internally.
 	GenerateSigningKey *bool `json:"generateSigningKey,omitempty" tf:"generate_signing_key,omitempty"`
 
-	// Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	KeyBits *float64 `json:"keyBits,omitempty" tf:"key_bits,omitempty"`
 
-	// Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`
 
@@ -69,11 +67,9 @@ type SecretBackendCAObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	KeyBits *float64 `json:"keyBits,omitempty" tf:"key_bits,omitempty"`
 
-	// Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`
 
@@ -111,12 +107,10 @@ type SecretBackendCAParameters struct {
 	// +kubebuilder:validation:Optional
 	GenerateSigningKey *bool `json:"generateSigningKey,omitempty" tf:"generate_signing_key,omitempty"`
 
-	// Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	// +kubebuilder:validation:Optional
 	KeyBits *float64 `json:"keyBits,omitempty" tf:"key_bits,omitempty"`
 
-	// Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
 	// Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
 	// +kubebuilder:validation:Optional
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`

--- a/apis/terraform/v1alpha1/zz_cloudsecretbackend_types.go
+++ b/apis/terraform/v1alpha1/zz_cloudsecretbackend_types.go
@@ -15,8 +15,7 @@ import (
 
 type CloudSecretBackendInitParameters struct {
 
-	// The default is
-	// https://app.0.0.1:8500".
+	// 0.0.1:8500".
 	Address *string `json:"address,omitempty" tf:"address,omitempty"`
 
 	// The unique location this backend should be mounted at. Must not begin or end with a /
@@ -54,8 +53,7 @@ type CloudSecretBackendInitParameters struct {
 
 type CloudSecretBackendObservation struct {
 
-	// The default is
-	// https://app.0.0.1:8500".
+	// 0.0.1:8500".
 	Address *string `json:"address,omitempty" tf:"address,omitempty"`
 
 	// The unique location this backend should be mounted at. Must not begin or end with a /
@@ -93,8 +91,7 @@ type CloudSecretBackendObservation struct {
 
 type CloudSecretBackendParameters struct {
 
-	// The default is
-	// https://app.0.0.1:8500".
+	// 0.0.1:8500".
 	// +kubebuilder:validation:Optional
 	Address *string `json:"address,omitempty" tf:"address,omitempty"`
 

--- a/apis/vault/v1alpha1/zz_mount_types.go
+++ b/apis/vault/v1alpha1/zz_mount_types.go
@@ -20,8 +20,6 @@ type MountInitParameters struct {
 	// +listType=set
 	AllowedManagedKeys []*string `json:"allowedManagedKeys,omitempty" tf:"allowed_managed_keys,omitempty"`
 
-	// List of headers to allow, allowing a plugin to include
-	// them in the response.
 	// List of headers to allow and pass from the request to the plugin
 	AllowedResponseHeaders []*string `json:"allowedResponseHeaders,omitempty" tf:"allowed_response_headers,omitempty"`
 
@@ -37,8 +35,6 @@ type MountInitParameters struct {
 	// Default lease duration for tokens and secrets in seconds
 	DefaultLeaseTTLSeconds *float64 `json:"defaultLeaseTtlSeconds,omitempty" tf:"default_lease_ttl_seconds,omitempty"`
 
-	// List of allowed authentication mount accessors the
-	// backend can request delegated authentication for.
 	// List of headers to allow and pass from the request to the plugin
 	DelegatedAuthAccessors []*string `json:"delegatedAuthAccessors,omitempty" tf:"delegated_auth_accessors,omitempty"`
 
@@ -50,13 +46,9 @@ type MountInitParameters struct {
 	// Enable the secrets engine to access Vault's external entropy source
 	ExternalEntropyAccess *bool `json:"externalEntropyAccess,omitempty" tf:"external_entropy_access,omitempty"`
 
-	// The key to use for signing plugin workload identity tokens. If
-	// not provided, this will default to Vault's OIDC default key.
 	// The key to use for signing plugin workload identity tokens
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// Specifies whether to show this mount in the UI-specific
-	// listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
 	// Specifies whether to show this mount in the UI-specific listing endpoint
 	ListingVisibility *string `json:"listingVisibility,omitempty" tf:"listing_visibility,omitempty"`
 
@@ -80,8 +72,6 @@ type MountInitParameters struct {
 	// +mapType=granular
 	Options map[string]*string `json:"options,omitempty" tf:"options,omitempty"`
 
-	// List of headers to allow and pass from the request to
-	// the plugin.
 	// List of headers to allow and pass from the request to the plugin
 	PassthroughRequestHeaders []*string `json:"passthroughRequestHeaders,omitempty" tf:"passthrough_request_headers,omitempty"`
 
@@ -89,9 +79,6 @@ type MountInitParameters struct {
 	// Where the secret backend will be mounted
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-	// If unspecified, the server will select any matching unversioned plugin that may have been
-	// registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
 	// Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
 	PluginVersion *string `json:"pluginVersion,omitempty" tf:"plugin_version,omitempty"`
 
@@ -115,8 +102,6 @@ type MountObservation struct {
 	// +listType=set
 	AllowedManagedKeys []*string `json:"allowedManagedKeys,omitempty" tf:"allowed_managed_keys,omitempty"`
 
-	// List of headers to allow, allowing a plugin to include
-	// them in the response.
 	// List of headers to allow and pass from the request to the plugin
 	AllowedResponseHeaders []*string `json:"allowedResponseHeaders,omitempty" tf:"allowed_response_headers,omitempty"`
 
@@ -132,8 +117,6 @@ type MountObservation struct {
 	// Default lease duration for tokens and secrets in seconds
 	DefaultLeaseTTLSeconds *float64 `json:"defaultLeaseTtlSeconds,omitempty" tf:"default_lease_ttl_seconds,omitempty"`
 
-	// List of allowed authentication mount accessors the
-	// backend can request delegated authentication for.
 	// List of headers to allow and pass from the request to the plugin
 	DelegatedAuthAccessors []*string `json:"delegatedAuthAccessors,omitempty" tf:"delegated_auth_accessors,omitempty"`
 
@@ -147,13 +130,9 @@ type MountObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// The key to use for signing plugin workload identity tokens. If
-	// not provided, this will default to Vault's OIDC default key.
 	// The key to use for signing plugin workload identity tokens
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// Specifies whether to show this mount in the UI-specific
-	// listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
 	// Specifies whether to show this mount in the UI-specific listing endpoint
 	ListingVisibility *string `json:"listingVisibility,omitempty" tf:"listing_visibility,omitempty"`
 
@@ -177,8 +156,6 @@ type MountObservation struct {
 	// +mapType=granular
 	Options map[string]*string `json:"options,omitempty" tf:"options,omitempty"`
 
-	// List of headers to allow and pass from the request to
-	// the plugin.
 	// List of headers to allow and pass from the request to the plugin
 	PassthroughRequestHeaders []*string `json:"passthroughRequestHeaders,omitempty" tf:"passthrough_request_headers,omitempty"`
 
@@ -186,9 +163,6 @@ type MountObservation struct {
 	// Where the secret backend will be mounted
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-	// If unspecified, the server will select any matching unversioned plugin that may have been
-	// registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
 	// Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
 	PluginVersion *string `json:"pluginVersion,omitempty" tf:"plugin_version,omitempty"`
 
@@ -209,8 +183,6 @@ type MountParameters struct {
 	// +listType=set
 	AllowedManagedKeys []*string `json:"allowedManagedKeys,omitempty" tf:"allowed_managed_keys,omitempty"`
 
-	// List of headers to allow, allowing a plugin to include
-	// them in the response.
 	// List of headers to allow and pass from the request to the plugin
 	// +kubebuilder:validation:Optional
 	AllowedResponseHeaders []*string `json:"allowedResponseHeaders,omitempty" tf:"allowed_response_headers,omitempty"`
@@ -230,8 +202,6 @@ type MountParameters struct {
 	// +kubebuilder:validation:Optional
 	DefaultLeaseTTLSeconds *float64 `json:"defaultLeaseTtlSeconds,omitempty" tf:"default_lease_ttl_seconds,omitempty"`
 
-	// List of allowed authentication mount accessors the
-	// backend can request delegated authentication for.
 	// List of headers to allow and pass from the request to the plugin
 	// +kubebuilder:validation:Optional
 	DelegatedAuthAccessors []*string `json:"delegatedAuthAccessors,omitempty" tf:"delegated_auth_accessors,omitempty"`
@@ -246,14 +216,10 @@ type MountParameters struct {
 	// +kubebuilder:validation:Optional
 	ExternalEntropyAccess *bool `json:"externalEntropyAccess,omitempty" tf:"external_entropy_access,omitempty"`
 
-	// The key to use for signing plugin workload identity tokens. If
-	// not provided, this will default to Vault's OIDC default key.
 	// The key to use for signing plugin workload identity tokens
 	// +kubebuilder:validation:Optional
 	IdentityTokenKey *string `json:"identityTokenKey,omitempty" tf:"identity_token_key,omitempty"`
 
-	// Specifies whether to show this mount in the UI-specific
-	// listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
 	// Specifies whether to show this mount in the UI-specific listing endpoint
 	// +kubebuilder:validation:Optional
 	ListingVisibility *string `json:"listingVisibility,omitempty" tf:"listing_visibility,omitempty"`
@@ -282,8 +248,6 @@ type MountParameters struct {
 	// +mapType=granular
 	Options map[string]*string `json:"options,omitempty" tf:"options,omitempty"`
 
-	// List of headers to allow and pass from the request to
-	// the plugin.
 	// List of headers to allow and pass from the request to the plugin
 	// +kubebuilder:validation:Optional
 	PassthroughRequestHeaders []*string `json:"passthroughRequestHeaders,omitempty" tf:"passthrough_request_headers,omitempty"`
@@ -293,9 +257,6 @@ type MountParameters struct {
 	// +kubebuilder:validation:Optional
 	Path *string `json:"path,omitempty" tf:"path,omitempty"`
 
-	// Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-	// If unspecified, the server will select any matching unversioned plugin that may have been
-	// registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
 	// Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
 	// +kubebuilder:validation:Optional
 	PluginVersion *string `json:"pluginVersion,omitempty" tf:"plugin_version,omitempty"`

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+)
+
+const (
+	// SelfPackagePath is the golang path for this package.
+	SelfPackagePath = "github.com/upbound/provider-vault/config/common"
+
+	// AccessorExtractor is the golang path to ExtractAccessor function
+	// in this package.
+	CsrExtractor = SelfPackagePath + ".ExtractCsr()"
+	CrtExtractor = SelfPackagePath + ".ExtractCrt()"
+)
+
+// ExtractCsr extracts the csr from the
+func ExtractCsr() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		paved, err := fieldpath.PaveObject(mg)
+		if err != nil {
+			return ""
+		}
+		r, err := paved.GetString("status.atProvider.csr")
+		if err != nil {
+			return ""
+		}
+		return r
+	}
+}
+
+func ExtractCrt() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		paved, err := fieldpath.PaveObject(mg)
+		if err != nil {
+			return ""
+		}
+		r, err := paved.GetString("status.atProvider.certificate")
+		if err != nil {
+			return ""
+		}
+		return r
+	}
+}

--- a/config/provider-metadata.yaml
+++ b/config/provider-metadata.yaml
@@ -39,6 +39,7 @@ resources:
             postal_code: '- (Optional) The postal code'
             province: '- (Optional) The province'
             revoke: '- If set to true, the certificate will be revoked on resource destruction.'
+            serial: '- Use serial_number instead.'
             serial_number: '- The certificate''s serial number, hex formatted.'
             street_address: '- (Optional) The street address'
             ttl: '- (Optional) Time to live'
@@ -87,6 +88,7 @@ resources:
                 - (Optional) If set, opts out of mount migration on path updates.
                 See here for more info on Mount Migration
             discoverdn: '- (Optional) Use anonymous bind to discover the bind Distinguished Name of a user.'
+            formatter: '- (Optional)  Deprecated use password_policy. Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix".'
             groupattr: |-
                 - (Optional) LDAP attribute to follow on objects returned by  in order to enumerate
                 user group membership. Examples: cn or memberOf, etc. Defaults to cn.
@@ -100,6 +102,9 @@ resources:
             last_rotation_tolerance: |-
                 - (Optional) The number of seconds after a Vault rotation where, if Active Directory
                 shows a later rotation, it should be considered out-of-band
+            length: |-
+                - (Optional) Deprecated use password_policy. The desired length of passwords that Vault generates.
+                Mutually exclusive with
             local: |-
                 - (Optional) Mark the secrets engine as local-only. Local engines are not replicated or removed by
                 replication.Tolerance duration to use when checking the last rotation time.
@@ -110,7 +115,7 @@ resources:
                 The value should not contain leading or trailing forward slashes.
                 The namespace is always relative to the provider's configured namespace.
                 Available only for Vault Enterprise.
-            password_policy: '- (Optional) Name of the password policy to use to generate passwords.'
+            password_policy: on vault-1.11+
             request_timeout: |-
                 - (Optional) Timeout, in seconds, for the connection when making requests against the server
                 before returning back an error.
@@ -572,7 +577,10 @@ resources:
             allowed_dns_sans: '- (Optional array: []) Allowed alternative dns names for authenticated client certificates'
             allowed_email_sans: '- (Optional array: []) Allowed emails for authenticated client certificates'
             allowed_names: '- (Optional string) DEPRECATED: Please use the individual allowed_X_sans parameters instead. Allowed subject names for authenticated client certificates'
-            allowed_organizational_units: '- (Optional array: []) Allowed organization units for authenticated client certificates.'
+            allowed_organization_units: ', please update accordingly'
+            allowed_organizational_units: |-
+                - (Optional array: []) Allowed organization units for authenticated client certificates.
+                In previous provider releases this field was incorrectly named
             allowed_uri_sans: '- (Optional array: []) Allowed URIs for authenticated client certificates'
             backend: '- (Optional string: "cert") Path to the mounted Cert auth backend'
             certificate: '- (Required string) CA certificate used to validate client certificates'
@@ -676,41 +684,6 @@ resources:
             token: |-
                 - (Optional) The Okta API token. This is required to query Okta for user group membership.
                 If this is not supplied only locally configured groups will be enabled.
-            token_bound_cidrs: |-
-                - (Optional) List of CIDR blocks; if set, specifies blocks of IP
-                addresses which can authenticate successfully, and ties the resulting token to these blocks
-                as well.
-            token_explicit_max_ttl: |-
-                - (Optional) If set, will encode an
-                explicit max TTL
-                onto the token in number of seconds. This is a hard cap even if token_ttl and
-                token_max_ttl would otherwise allow a renewal.
-            token_max_ttl: |-
-                - (Optional) The maximum lifetime for generated tokens in number of seconds.
-                Its current value will be referenced at renewal time.
-            token_no_default_policy: |-
-                - (Optional) If set, the default policy will not be set on
-                generated tokens; otherwise it will be added to the policies set in token_policies.
-            token_num_uses: |-
-                - (Optional) The maximum number
-                of times a generated token may be used (within its lifetime); 0 means unlimited.
-            token_period: |-
-                - (Optional) If set, indicates that the
-                token generated using this role should never expire. The token should be renewed within the
-                duration specified by this value. At each renewal, the token's TTL will be set to the
-                value of this field. Specified in seconds.
-            token_policies: |-
-                - (Optional) List of policies to encode onto generated tokens. Depending
-                on the auth method, this list may be supplemented by user/group/other values.
-            token_ttl: |-
-                - (Optional) The incremental lifetime for generated tokens in number of seconds.
-                Its current value will be referenced at renewal time.
-            token_type: |-
-                - (Optional) The type of token that should be generated. Can be service,
-                batch, or default to use the mount's tuned default (which unless changed will be
-                service tokens). For token store roles, there are two additional possibilities:
-                default-service and default-batch which specify the type to return unless the client
-                requests a different type at generation time.
             ttl: |-
                 - (Optional) Duration after which authentication will be expired.
                 See the documentation for info on valid duration formats.
@@ -797,18 +770,6 @@ resources:
             - name: example
               manifest: |-
                 {
-                  "identity_token_audience": "\u003cTOKEN_AUDIENCE\u003e",
-                  "identity_token_ttl": "\u003cTOKEN_TTL\u003e",
-                  "role_arn": "\u003cAWS_ROLE_ARN\u003e"
-                }
-              dependencies:
-                vault_auth_backend.example: |-
-                    {
-                      "type": "aws"
-                    }
-            - name: example
-              manifest: |-
-                {
                   "access_key": "INSERT_AWS_ACCESS_KEY",
                   "backend": "${vault_auth_backend.example.path}",
                   "secret_key": "INSERT_AWS_SECRET_KEY"
@@ -823,7 +784,7 @@ resources:
         argumentDocs:
             access_key: |-
                 - (Optional) The AWS access key that Vault should use for the
-                auth backend. Mutually exclusive with identity_token_audience.
+                auth backend.
             backend: |-
                 - (Optional) The path the AWS auth backend being configured was
                 mounted at.  Defaults to aws.
@@ -837,23 +798,11 @@ resources:
                 - (Optional) The value to require in the
                 X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity requests
                 that are used in the IAM auth method.
-            identity_token_audience: |-
-                - (Optional) The audience claim value. Mutually exclusive with access_key.
-                Requires Vault 1.17+. Available only for Vault Enterprise
-            identity_token_ttl: |-
-                - (Optional) The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                Available only for Vault Enterprise
-            max_retries: |-
-                - (Optional) Number of max retries the client should use for recoverable errors.
-                The default -1 falls back to the AWS SDK's default behavior.
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
                 The value should not contain leading or trailing forward slashes.
                 The namespace is always relative to the provider's configured namespace.
                 Available only for Vault Enterprise.
-            role_arn: |-
-                - (Optional) Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-                Available only for Vault Enterprise
             secret_key: |-
                 - (Optional) The AWS secret key that Vault should use for the
                 auth backend.
@@ -1448,9 +1397,6 @@ resources:
                 and a default TTL is specified on the role,
                 then this default TTL will be used. Valid only when credential_type is one of
                 assumed_role or federation_token.
-            external_id: |-
-                (Optional) - External ID to set for assume role creds.
-                Valid only when credential_type is set to assumed_role.
             iam_groups: |-
                 (Optional) - A list of IAM group names. IAM users generated
                 against this vault role will be added to these IAM Groups. For a credential
@@ -1458,9 +1404,6 @@ resources:
                 corresponding AWS call (sts:AssumeRole or sts:GetFederation) will be the
                 policies from each group in iam_groups combined with the policy_document
                 and policy_arns parameters.
-            iam_tags: |-
-                (Optional) - A map of strings representing key/value pairs
-                to be used as tags for any IAM user that is created by this role.
             max_sts_ttl: |-
                 - (Optional) The max allowed TTL in seconds for STS credentials
                 (credentials TTL are capped to max_sts_ttl). Valid only when credential_type is
@@ -1496,10 +1439,6 @@ resources:
                 - (Optional) Specifies the ARNs of the AWS roles this Vault role
                 is allowed to assume. Required when credential_type is assumed_role and
                 prohibited otherwise.
-            session_tags: |-
-                (Optional) - A map of strings representing key/value pairs to be set
-                during assume role creds creation. Valid only when credential_type is set to
-                assumed_role.
             user_path: |-
                 - (Optional) The path for the user name. Valid only when
                 credential_type is iam_user. Default is /.
@@ -1552,23 +1491,6 @@ resources:
                 {
                   "backend": "${vault_auth_backend.example.path}",
                   "client_id": "11111111-2222-3333-4444-555555555555",
-                  "identity_token_audience": "\u003cTOKEN_AUDIENCE\u003e",
-                  "identity_token_ttl": "\u003cTOKEN_TTL\u003e",
-                  "tenant_id": "11111111-2222-3333-4444-555555555555"
-                }
-              references:
-                backend: vault_auth_backend.example.path
-              dependencies:
-                vault_auth_backend.example: |-
-                    {
-                      "identity_token_key": "example-key",
-                      "type": "azure"
-                    }
-            - name: example
-              manifest: |-
-                {
-                  "backend": "${vault_auth_backend.example.path}",
-                  "client_id": "11111111-2222-3333-4444-555555555555",
                   "client_secret": "01234567890123456789",
                   "resource": "https://vault.hashicorp.com",
                   "tenant_id": "11111111-2222-3333-4444-555555555555"
@@ -1594,13 +1516,6 @@ resources:
                 - (Optional) The Azure cloud environment. Valid values:
                 AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud,
                 AzureGermanCloud.  Defaults to AzurePublicCloud.
-            identity_token_audience: |-
-                - (Optional) The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-                Available only for Vault Enterprise
-            identity_token_ttl: |-
-                - (Optional) The TTL of generated identity tokens in seconds.
-                Defaults to 1 hour. Uses duration format strings.
-                Requires Vault 1.17+. Available only for Vault Enterprise
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
                 The value should not contain leading or trailing forward slashes.
@@ -1722,15 +1637,6 @@ resources:
               manifest: |-
                 {
                   "client_id": "11111111-2222-3333-4444-333333333333",
-                  "identity_token_audience": "\u003cTOKEN_AUDIENCE\u003e",
-                  "identity_token_ttl": "\u003cTOKEN_TTL\u003e",
-                  "subscription_id": "11111111-2222-3333-4444-111111111111",
-                  "tenant_id": "11111111-2222-3333-4444-222222222222"
-                }
-            - name: azure
-              manifest: |-
-                {
-                  "client_id": "11111111-2222-3333-4444-333333333333",
                   "client_secret": "12345678901234567890",
                   "environment": "AzurePublicCloud",
                   "subscription_id": "11111111-2222-3333-4444-111111111111",
@@ -1754,15 +1660,6 @@ resources:
                 - (Optional) If set, opts out of mount migration on path updates.
                 See here for more info on Mount Migration
             environment: (string:"") - The Azure environment.
-            identity_token_audience: |-
-                - (Optional) The audience claim value. Requires Vault 1.17+.
-                Available only for Vault Enterprise
-            identity_token_key: |-
-                - (Optional) The key to use for signing identity tokens. Requires Vault 1.17+.
-                Available only for Vault Enterprise
-            identity_token_ttl: |-
-                - (Optional) The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                Available only for Vault Enterprise
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
                 The value should not contain leading or trailing forward slashes.
@@ -1856,42 +1753,6 @@ resources:
             ttl: |-
                 – (Optional) Specifies the default TTL for service principals generated using this role.
                 Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
-        importStatements: []
-    vault_config_ui_custom_message:
-        subCategory: ""
-        description: Manages a UI custom message in Vault.
-        name: vault_config_ui_custom_message
-        title: vault_config_ui_custom_message resource
-        examples:
-            - name: maintenance
-              manifest: |-
-                {
-                  "authenticated": true,
-                  "end_time": "2024-02-01T05:00:00.000Z",
-                  "message": "${base64encode(\"Vault will be offline for planned maintenance on February 1st, 2024 from 05:00Z to 08:00Z\")}",
-                  "start_time": "2024-01-01T00:00:00.000Z",
-                  "title": "Upcoming maintenance",
-                  "type": "banner"
-                }
-        argumentDocs:
-            authenticated: |-
-                - (Optional) The value true if the custom message is displayed after logins are completed or false if they are
-                displayed during the login in the Vault UI. The default value is true.
-            end_time: '- (Optional) The time when the custom message expires. If this value is not specified, the custom message never expires.'
-            href: '- (Required) The URL set in the hyperlink''s href attribute.'
-            link: '- (Optional) A hyperlink to be included with the message. See below for more details.'
-            message: '- (Required) The base64-encoded content of the custom message.'
-            namespace: |-
-                - (Optional) The namespace to provision the resource in.
-                The value should not contain leading or trailing forward slashes.
-                The namespace is always relative to the provider's configured namespace.
-                Available only for Vault Enterprise.
-            options: '- (Optional) A map of additional options that can be set on the custom message.'
-            start_time: |-
-                - (Required) The time when the custom message begins to be active. This value can be set to a future time, but cannot
-                occur on or after the end_time value.
-            title: '- (Required) The title of the custom message to create.'
-            type: '- (Optional) The presentation type of the custom message. Must be one of the following values: banner or modal.'
         importStatements: []
     vault_consul_secret_backend:
         subCategory: ""
@@ -2002,6 +1863,9 @@ resources:
             service_identities: |-
                 - (Optional)SEE NOTE Set of Consul
                 service identities to attach to the token. Applicable for Vault 1.11+ with Consul 1.5+.
+            token_type: |-
+                - (Optional) Specifies the type of token to create when using this role. Valid values are "client" or "management".
+                Deprecated: Consul 1.11 and later removed the legacy ACL system which supported this field.
             ttl: '- (Optional) Specifies the TTL for this role.'
         importStatements: []
     vault_database_secret_backend_connection:
@@ -2634,18 +2498,9 @@ resources:
             - name: gcp
               manifest: |-
                 {
-                  "identity_token_audience": "\u003cTOKEN_AUDIENCE\u003e",
-                  "identity_token_key": "example-key",
-                  "identity_token_ttl": 1800,
-                  "service_account_email": "\u003cSERVICE_ACCOUNT_EMAIL\u003e"
-                }
-            - name: gcp
-              manifest: |-
-                {
                   "credentials": "${file(\"credentials.json\")}"
                 }
         argumentDocs:
-            accessor: '- The accessor of the created GCP mount.'
             credentials: '- (Optional) The GCP service account credentials in JSON format.'
             default_lease_ttl_seconds: |-
                 - (Optional) The default TTL for credentials
@@ -2654,17 +2509,6 @@ resources:
             disable_remount: |-
                 - (Optional) If set, opts out of mount migration on path updates.
                 See here for more info on Mount Migration
-            identity_token_audience: |-
-                - (Optional) The audience claim value for plugin identity
-                tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-                Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
-            identity_token_key: |-
-                - (Optional) The key to use for signing plugin identity
-                tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
-            identity_token_ttl: |-
-                - (Optional) The TTL of generated tokens. Defaults to
-                1 hour. Uses duration format strings.
-                Requires Vault 1.17+. Available only for Vault Enterprise.
             local: '- (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment'
             max_lease_ttl_seconds: |-
                 - (Optional) The maximum TTL that can be requested
@@ -2677,9 +2521,6 @@ resources:
             path: |-
                 - (Optional) The unique path this backend should be mounted at. Must
                 not begin or end with a /. Defaults to gcp.
-            service_account_email: |-
-                – (Optional) Service Account to impersonate for plugin workload identity federation.
-                Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
         importStatements: []
     vault_gcp_secret_impersonated_account:
         subCategory: ""
@@ -3499,6 +3340,10 @@ resources:
             exclusive: '- (Optional) Defaults to true.'
             "false": ', this resource will simply ensure that the member entities specified in the resource are present in the group. When destroying the resource, the resource will ensure that the member entities specified in the resource are removed.'
             group_id: '- (Required) Group ID to assign member entities to.'
+            group_name: |-
+                - The name of the group that are assigned the member entities.
+                Deprecated: The value for group_name may not always be accurate
+                use data.vault_identity_group.*.group_name, or vault_identity_group.*.group_name instead.
             member_entity_ids: '- (Required) List of member entities that belong to the group'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
@@ -3916,10 +3761,6 @@ resources:
         argumentDocs:
             access_token_ttl: '- (Optional) The time-to-live for access tokens obtained by the client.'
             assignments: '- (Optional) A list of assignment resources associated with the client.'
-            client_id: '- The Client ID returned by Vault.'
-            client_secret: |-
-                - The Client Secret Key returned by Vault.
-                For public OpenID Clients client_secret is set to an empty string ""
             client_type: |-
                 - (Optional) The client type based on its ability to maintain confidentiality of credentials.
                 The following client types are supported: confidential, public. Defaults to confidential.
@@ -4345,8 +4186,9 @@ resources:
                 - (Optional) The unique name of the auth backend to configure.
                 Defaults to jwt.
             bound_audiences: |-
-                - (Required for roles of type jwt, optional for roles of
-                type oidc) List of aud claims to match against. Any match is sufficient.
+                - (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+                or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+                Any match is sufficient.
             bound_claims: |-
                 - (Optional) If set, a map of claims to values to match against.
                 A claim's value must be a string, which may contain one value or multiple
@@ -4367,7 +4209,7 @@ resources:
                 Only applicable with "jwt" roles.
             expiration_leeway: |-
                 - (Optional) The amount of leeway to add to expiration (exp) claims to account for
-                clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                 Only applicable with "jwt" roles.
             groups_claim: |-
                 - (Optional) The claim to use to uniquely identify
@@ -4384,7 +4226,7 @@ resources:
                 Available only for Vault Enterprise.
             not_before_leeway: |-
                 - (Optional) The amount of leeway to add to not before (nbf) claims to account for
-                clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                 Only applicable with "jwt" roles.
             oidc_scopes: |-
                 - (Optional) If set, a list of OIDC scopes to be used with an OIDC role.
@@ -4841,15 +4683,9 @@ resources:
                       "service_account_jwt": "${file(\"/path/to/token\")}"
                     }
         argumentDocs:
-            allowed_kubernetes_namespace_selector: |-
-                - (Optional) A label selector for Kubernetes namespaces
-                in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-                of type LabelSelector.
-                If set with allowed_kubernetes_namespace, the conditions are ORed.
             allowed_kubernetes_namespaces: |-
-                - (Optional) The list of Kubernetes namespaces this role
-                can generate credentials for. If set to * all namespaces are allowed. If set with
-                allowed_kubernetes_namespace_selector, the conditions are ORed.
+                - (Required) The list of Kubernetes namespaces this role
+                can generate credentials for. If set to * all namespaces are allowed.
             backend: |-
                 - (Required) The path of the Kubernetes Secrets Engine backend mount to create
                 the role in.
@@ -5077,6 +4913,9 @@ resources:
             insecure_tls: |-
                 - (Optional) Skip LDAP server SSL Certificate verification. This is not recommended for production.
                 Defaults to false.
+            length: |-
+                - (Optional) Deprecated use password_policy. The desired length of passwords that Vault generates.
+                Mutually exclusive with
             local: |-
                 - (Optional) Mark the secrets engine as local-only. Local engines are not replicated or removed by
                 replication.Tolerance duration to use when checking the last rotation time.
@@ -5086,7 +4925,7 @@ resources:
                 The value should not contain leading or trailing forward slashes.
                 The namespace is always relative to the provider's configured namespace.
                 Available only for Vault Enterprise.
-            password_policy: '- (Optional) Name of the password policy to use to generate passwords.'
+            password_policy: on vault-1.11+
             path: |-
                 - (Optional) The unique path this backend should be mounted at. Must
                 not begin or end with a /. Defaults to ldap.
@@ -5094,9 +4933,6 @@ resources:
                 - (Optional) Timeout, in seconds, for the connection when making requests against the server
                 before returning back an error.
             schema: '- (Optional)  The LDAP schema to use when storing entry passwords. Valid schemas include openldap, ad, and racf. Default is openldap.'
-            skip_static_role_import_rotation: |-
-                - (Optional) If set to true, static roles will not be rotated during import.
-                Defaults to false. Requires Vault 1.16 or above.
             starttls: '- (Optional) Issue a StartTLS command after establishing unencrypted connection.'
             upndomain: '- (Optional) Enables userPrincipalDomain login with [username]@UPNDomain.'
             url: |-
@@ -5267,9 +5103,6 @@ resources:
                 Available only for Vault Enterprise.
             role_name: '- (Required) Name of the role.'
             rotation_period: '- (Required) How often Vault should rotate the password of the user entry.'
-            skip_import_rotation: |-
-                - (Optional) Causes vault to skip the initial secret rotation on import. Not applicable to updates.
-                Requires Vault 1.16 or above.
             username: '- (Required) The username of the existing LDAP entry to manage password rotation for.'
         importStatements: []
     vault_managed_keys:
@@ -5552,12 +5385,10 @@ resources:
             - name: config
               manifest: |-
                 {
-                  "mount": "${vault_mount.mongo.path}",
+                  "mount": "vault_mount.mongo.path",
                   "private_key": "privateKey",
                   "public_key": "publicKey"
                 }
-              references:
-                mount: vault_mount.mongo.path
               dependencies:
                 vault_mount.mongo: |-
                     {
@@ -5591,12 +5422,8 @@ resources:
                   "name": "tf-test-role",
                   "organization_id": "7cf5a45a9ccf6400e60981b7",
                   "project_id": "5cf5a45a9ccf6400e60981b6",
-                  "project_roles": [
-                    "GROUP_READ_ONLY"
-                  ],
-                  "roles": [
-                    "ORG_READ_ONLY"
-                  ],
+                  "project_roles": "GROUP_READ_ONLY",
+                  "roles": "ORG_READ_ONLY",
                   "ttl": "60"
                 }
               references:
@@ -5604,7 +5431,7 @@ resources:
               dependencies:
                 vault_mongodbatlas_secret_backend.config: |-
                     {
-                      "mount": "${vault_mount.mongo.path}",
+                      "mount": "vault_mount.mongo.path",
                       "private_key": "privateKey",
                       "public_key": "publicKey"
                     }
@@ -5631,8 +5458,8 @@ resources:
             project_id: |-
                 - (Optional) Unique identifier for the project to which the target API Key belongs.
                 Required if organization_id is not set.
-            project_roles: '- (Optional) Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.'
-            roles: '- (Required) List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.'
+            project_roles: '- (Optional) Roles assigned when an org API key is assigned to a project API key.'
+            roles: '- (Required) List of roles that the API Key needs to have.'
             ttl: '- (Optional) Duration in seconds after which the issued credential should expire.'
         importStatements: []
     vault_mount:
@@ -5681,23 +5508,11 @@ resources:
         argumentDocs:
             accessor: '- The accessor for this mount.'
             allowed_managed_keys: '- (Optional) Set of managed key registry entry names that the mount in question is allowed to access'
-            allowed_response_headers: |-
-                - (Optional) List of headers to allow, allowing a plugin to include
-                them in the response.
             audit_non_hmac_request_keys: '- (Optional) Specifies the list of keys that will not be HMAC''d by audit devices in the request data object.'
             audit_non_hmac_response_keys: '- (Optional) Specifies the list of keys that will not be HMAC''d by audit devices in the response data object.'
             default_lease_ttl_seconds: '- (Optional) Default lease duration for tokens and secrets in seconds'
-            delegated_auth_accessors: |-
-                - (Optional)  List of allowed authentication mount accessors the
-                backend can request delegated authentication for.
             description: '- (Optional) Human-friendly description of the mount'
             external_entropy_access: '- (Optional) Boolean flag that can be explicitly set to true to enable the secrets engine to access Vault''s external entropy source'
-            identity_token_key: |-
-                - (Optional)  The key to use for signing plugin workload identity tokens. If
-                not provided, this will default to Vault's OIDC default key.
-            listing_visibility: |-
-                - (Optional) Specifies whether to show this mount in the UI-specific
-                listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
             local: '- (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment'
             max_lease_ttl_seconds: '- (Optional) Maximum possible lease duration for tokens and secrets in seconds'
             namespace: |-
@@ -5706,14 +5521,7 @@ resources:
                 The namespace is always relative to the provider's configured namespace.
                 Available only for Vault Enterprise.
             options: '- (Optional) Specifies mount type specific options that are passed to the backend'
-            passthrough_request_headers: |-
-                - (Optional) List of headers to allow and pass from the request to
-                the plugin.
             path: '- (Required) Where the secret backend will be mounted'
-            plugin_version: |-
-                - (Optional) Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-                If unspecified, the server will select any matching unversioned plugin that may have been
-                registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
             seal_wrap: '- (Optional) Boolean flag that can be explicitly set to true to enable seal wrapping for the mount, causing values stored by the mount to be wrapped by the seal''s encryption capability'
             type: '- (Required) Type of the backend, such as "aws"'
         importStatements: []
@@ -5999,137 +5807,6 @@ resources:
                 Available only for Vault Enterprise.
             pem_bundle: '- (Required) The key and certificate PEM bundle'
         importStatements: []
-    vault_pki_secret_backend_config_cluster:
-        subCategory: ""
-        description: Sets the cluster configuration on an PKI Secret Backend for Vault.
-        name: vault_pki_secret_backend_config_cluster
-        title: vault_pki_secret_backend_config_cluster resource
-        examples:
-            - name: example
-              manifest: |-
-                {
-                  "aia_path": "http://127.0.0.1:8200/v1/pki-root",
-                  "backend": "${vault_mount.root.path}",
-                  "path": "http://127.0.0.1:8200/v1/pki-root"
-                }
-              references:
-                backend: vault_mount.root.path
-              dependencies:
-                vault_mount.root: |-
-                    {
-                      "default_lease_ttl_seconds": 8640000,
-                      "description": "root PKI",
-                      "max_lease_ttl_seconds": 8640000,
-                      "path": "pki-root",
-                      "type": "pki"
-                    }
-        argumentDocs:
-            aia_path: '- (Required) Specifies the path to this performance replication cluster''s AIA distribution point.'
-            backend: '- (Required) The path the PKI secret backend is mounted at, with no leading or trailing /s.'
-            namespace: |-
-                - (Optional) The namespace to provision the resource in.
-                The value should not contain leading or trailing forward slashes.
-                The namespace is always relative to the provider's configured namespace.
-                Available only for Vault Enterprise.
-            path: '- (Required) Specifies the path to this performance replication cluster''s API mount path.'
-        importStatements: []
-    vault_pki_secret_backend_config_est:
-        subCategory: ""
-        description: Sets the EST configuration on a PKI Secret Backend for Vault.
-        name: vault_pki_secret_backend_config_est
-        title: vault_pki_secret_backend_config_est resource
-        examples:
-            - name: example
-              manifest: |-
-                {
-                  "audit_fields": [
-                    "csr",
-                    "common_name",
-                    "alt_names",
-                    "ip_sans",
-                    "uri_sans",
-                    "other_sans",
-                    "signature_bits",
-                    "exclude_cn_from_sans",
-                    "ou",
-                    "organization",
-                    "country",
-                    "locality",
-                    "province",
-                    "street_address",
-                    "postal_code",
-                    "serial_number",
-                    "use_pss",
-                    "key_type",
-                    "key_bits",
-                    "add_basic_constraints"
-                  ],
-                  "authenticators": [
-                    {
-                      "cert": {
-                        "accessor": "test",
-                        "cert_role": "cert-auth-role"
-                      },
-                      "userpass": {
-                        "accessor": "test2"
-                      }
-                    }
-                  ],
-                  "backend": "${vault_mount.pki.path}",
-                  "default_mount": true,
-                  "default_path_policy": "${format(\"role:%s\", vault_pki_secret_backend_role.est_role.name)}",
-                  "enable_sentinel_parsing": true,
-                  "enabled": true,
-                  "label_to_path_policy": {
-                    "test-label": "sign-verbatim",
-                    "test-label-2": "${format(\"role:%s\", vault_pki_secret_backend_role.est_role_2.name)}"
-                  }
-                }
-              references:
-                backend: vault_mount.pki.path
-              dependencies:
-                vault_mount.pki: |-
-                    {
-                      "description": "PKI secret engine mount",
-                      "path": "pki-root",
-                      "type": "pki"
-                    }
-                vault_pki_secret_backend_role.est_role: |-
-                    {
-                      "backend": "${vault_mount.pki.path}",
-                      "key_bits": "256",
-                      "key_type": "ec",
-                      "name": "est-role",
-                      "ttl": 3600
-                    }
-                vault_pki_secret_backend_role.est_role_2: |-
-                    {
-                      "backend": "${vault_mount.pki.path}",
-                      "key_bits": "256",
-                      "key_type": "ec",
-                      "name": "est-role-2",
-                      "ttl": 3600
-                    }
-        argumentDocs:
-            audit_fields: '- (Optional) Fields parsed from the CSR that appear in the audit and can be used by sentinel policies.'
-            authenticators: '- (Optional) Lists the mount accessors EST should delegate authentication requests towards (see below for nested schema).'
-            backend: |-
-                - (Required) The path to the PKI secret backend to
-                read the EST configuration from, with no leading or trailing /s.
-            cert: '- "The accessor (required) and cert_role (optional) properties for cert auth backends".'
-            default_mount: '- (Optional) If set, this mount will register the default .well-known/est URL path. Only a single mount can enable this across a Vault cluster.'
-            default_path_policy: '- (Optional) Required to be set if default_mount is enabled. Specifies the behavior for requests using the default EST label. Can be sign-verbatim or a role given by role:<role_name>.'
-            enable_sentinel_parsing: '- (Optional) If set, parse out fields from the provided CSR making them available for Sentinel policies.'
-            enabled: '- (Optional) Specifies whether EST is enabled.'
-            label_to_path_policy: '- (Optional) Configures a pairing of an EST label with the redirected behavior for requests hitting that role. The path policy can be sign-verbatim or a role given by role:<role_name>. Labels must be unique across Vault cluster, and will register .well-known/est/ URL paths.'
-            last_updated: '- A read-only timestamp representing the last time the configuration was updated.'
-            namespace: |-
-                - (Optional) The namespace of the target resource.
-                The value should not contain leading or trailing forward slashes.
-                The namespace is always relative to the provider's configured namespace.
-                Available only for Vault Enterprise.
-            userpass: '- "The accessor (required) property for user pass auth backends".'
-        importStatements: []
     vault_pki_secret_backend_config_issuers:
         subCategory: ""
         description: Allows setting the value of the default issuer.
@@ -6212,7 +5889,6 @@ resources:
         argumentDocs:
             backend: '- (Required) The path the PKI secret backend is mounted at, with no leading or trailing /s.'
             crl_distribution_points: '- (Optional) Specifies the URL values for the CRL Distribution Points field.'
-            enable_templating: '- (Optional) Specifies that templating of AIA fields is allowed.'
             issuing_certificates: '- (Optional) Specifies the URL values for the Issuing Certificate field.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
@@ -6729,6 +6405,7 @@ resources:
             postal_code: '- (Optional) The postal code'
             private_key_format: '- (Optional) The private key format'
             province: '- (Optional) The province'
+            serial: '- Deprecated, use serial_number instead.'
             serial_number: '- The certificate''s serial number, hex formatted.'
             street_address: '- (Optional) The street address'
             ttl: '- (Optional) Time to live'
@@ -6784,84 +6461,10 @@ resources:
                 Available only for Vault Enterprise.
             other_sans: '- (Optional) List of other SANs'
             renew_pending: '- true if the current time (during refresh) is after the start of the early renewal window declared by min_seconds_remaining, and false otherwise; if auto_renew is set to true then the provider will plan to replace the certificate once renewal is pending.'
+            serial: '- Use serial_number instead.'
             serial_number: '- The certificate''s serial number, hex formatted.'
             ttl: '- (Optional) Time to live'
             uri_sans: '- (Optional) List of alternative URIs'
-        importStatements: []
-    vault_plugin:
-        subCategory: ""
-        description: Manage external plugins registered in the plugin catalog.
-        name: vault_plugin
-        title: vault_plugin resource
-        examples:
-            - name: jwt
-              manifest: |-
-                {
-                  "command": "vault-plugin-auth-jwt",
-                  "env": [
-                    "HTTP_PROXY=http://proxy.example.com:8080"
-                  ],
-                  "name": "jwt",
-                  "sha256": "6bd0a803ed742aa3ce35e4fa23d2c8d550e6c1567bf63410cec489c28b68b0fc",
-                  "type": "auth",
-                  "version": "v0.17.0"
-                }
-              dependencies:
-                vault_auth_backend.jwt_auth: |-
-                    {
-                      "type": "${vault_plugin.jwt.name}"
-                    }
-        argumentDocs:
-            args: '- (Optional) List of additional args to pass to the plugin.'
-            command: '- (Required) Command to execute the plugin, relative to the server''s configured plugin_directory.'
-            env: '- (Optional) List of additional environment variables to run the plugin with in KEY=VALUE form.'
-            name: '- (Required) Name of the plugin.'
-            oci_image: |-
-                - (Optional) Specifies OCI image to run. If specified, setting
-                command, args, and env will update the container's entrypoint, args, and
-                environment variables (append-only) respectively.
-            runtime: '- (Optional) Vault plugin runtime to use if oci_image is specified.'
-            sha256: '- (Required) SHA256 sum of the plugin binary.'
-            type: '- (Required) Type of plugin; one of "auth", "secret", or "database".'
-            version: '- (Optional) Semantic version of the plugin.'
-        importStatements: []
-    vault_plugin_pinned_version:
-        subCategory: ""
-        description: Manage pinned plugin version registered in the plugin catalog.
-        name: vault_plugin_pinned_version
-        title: vault_plugin_pinned_version resource
-        examples:
-            - name: jwt_pin
-              manifest: |-
-                {
-                  "name": "${vault_plugin.jwt.name}",
-                  "type": "${vault_plugin.jwt.type}",
-                  "version": "${vault_plugin.jwt.version}"
-                }
-              references:
-                name: vault_plugin.jwt.name
-                type: vault_plugin.jwt.type
-                version: vault_plugin.jwt.version
-              dependencies:
-                vault_auth_backend.jwt_auth: |-
-                    {
-                      "type": "${vault_plugin_pinned_version.jwt_pin.name}"
-                    }
-                vault_plugin.jwt: |-
-                    {
-                      "command": "vault-plugin-auth-jwt",
-                      "env": [
-                        "HTTP_PROXY=http://proxy.example.com:8080"
-                      ],
-                      "name": "jwt",
-                      "sha256": "6bd0a803ed742aa3ce35e4fa23d2c8d550e6c1567bf63410cec489c28b68b0fc",
-                      "type": "auth",
-                      "version": "v0.17.0"
-                    }
-        argumentDocs:
-            name: '- (Required) Name of the plugin.'
-            type: '- (Required) Type of plugin; one of "auth", "secret", or "database".'
-            version: '- (Required) Semantic version of the plugin to pin.'
         importStatements: []
     vault_policy:
         subCategory: ""
@@ -6898,7 +6501,6 @@ resources:
                   "path": ""
                 }
         argumentDocs:
-            inheritable: '- (Optional) If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.'
             max_leases: |-
                 - (Required) The maximum number of leases to be allowed by the quota
                 rule. The max_leases must be positive.
@@ -6934,7 +6536,6 @@ resources:
             block_interval: |-
                 - (Optional) If set, when a client reaches a rate limit threshold, the client will
                 be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
-            inheritable: '- (Optional) If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.'
             interval: '- (Optional) The duration in seconds to enforce rate limiting for.'
             name: '- (Required) Name of the rate limit quota'
             namespace: |-
@@ -7428,16 +7029,9 @@ resources:
                 The value should not contain leading or trailing forward slashes.
                 The namespace is always relative to the provider's configured namespace.
             secret_name: '- (Required) Specifies the name of the secret to synchronize.'
-            subkeys: '- A list of subkeys for the associated secret.'
-            sync_status: |-
-                - A map of sync statuses for each subkey of the associated secret
-                (for ex. {kv_624bea/aws-token/dev: "SYNCED", kv_624bea/aws-token/prod: "SYNCED"}).
+            sync_status: '- Specifies the status of the association (for eg. SYNCED).'
             type: '- (Required) Specifies the destination type.'
-            updated_at: |-
-                - A map of duration strings specifying when each subkey of the associated
-                secret was last updated.
-                (for ex.
-                {kv_624bea/aws-token/dev: "2024-03-21T12:42:02.558533-07:00", kv_624bea/aws-token/prod: "2024-03-21T12:42:02.558533-07:00"}).
+            updated_at: '- Duration string specifying when the secret was last updated.'
         importStatements: []
     vault_secrets_sync_aws_destination:
         subCategory: ""
@@ -7452,10 +7046,8 @@ resources:
                   "custom_tags": {
                     "foo": "bar"
                   },
-                  "external_id": "external-id",
                   "name": "aws-dest",
                   "region": "us-east-1",
-                  "role_arn": "role-arn",
                   "secret_access_key": "${var.secret_access_key}",
                   "secret_name_template": "vault_{{ .MountAccessor | lowercase }}_{{ .SecretPath | lowercase }}"
                 }
@@ -7468,15 +7060,6 @@ resources:
                 Can be omitted and directly provided to Vault using the AWS_ACCESS_KEY_ID environment
                 variable.
             custom_tags: '- (Optional) Custom tags to set on the secret managed at the destination.'
-            external_id: |-
-                - (Optional) Optional extra protection that must match the trust policy granting access to the
-                AWS IAM role ARN. We recommend using a different random UUID per destination. The value is generated by users.
-                The field is mutable with no special condition, but users must be careful that the new value fits with the trust
-                relationship condition they set on AWS otherwise sync operations will start to fail due to client-side access
-                denied errors. Ignored if the role_arn field is empty.
-            granularity: |-
-                - (Optional) Determines what level of information is synced as a distinct resource
-                at the destination. Supports secret-path and secret-key.
             name: '- (Required) Unique name of the AWS destination.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
@@ -7486,12 +7069,6 @@ resources:
                 - (Optional) Region where to manage the secrets manager entries.
                 Can be omitted and directly provided to Vault using the AWS_REGION environment
                 variable.
-            role_arn: |-
-                - (Optional) Specifies a role to assume when connecting to AWS. When assuming a role,
-                Vault uses temporary STS credentials to authenticate. An initial session with the proper trust relationship must
-                exist for Vault to be able to assume this role. The role can be in a different account.
-                The value is mutable as long as the new role targets the same AWS account ID. If not, the BE will return an error.
-                It is possible to provide both an access key pair and a role to assume.
             secret_access_key: |-
                 - (Optional) Secret access key to authenticate against the AWS secrets manager.
                 Can be omitted and directly provided to Vault using the AWS_SECRET_ACCESS_KEY environment
@@ -7536,9 +7113,6 @@ resources:
                 variable.
             cloud: '- (Optional) Specifies a cloud for the client. The default is Azure Public Cloud.'
             custom_tags: '- (Optional) Custom tags to set on the secret managed at the destination.'
-            granularity: |-
-                - (Optional) Determines what level of information is synced as a distinct resource
-                at the destination. Supports secret-path and secret-key.
             key_vault_uri: |-
                 - (Optional) URI of an existing Azure Key Vault instance.
                 Can be omitted and directly provided to Vault using the KEY_VAULT_URI environment
@@ -7591,7 +7165,6 @@ resources:
                     "foo": "bar"
                   },
                   "name": "gcp-dest",
-                  "project_id": "gcp-project-id",
                   "secret_name_template": "vault_{{ .MountAccessor | lowercase }}_{{ .SecretPath | lowercase }}"
                 }
         argumentDocs:
@@ -7600,19 +7173,11 @@ resources:
                 Can be omitted and directly provided to Vault using the GOOGLE_APPLICATION_CREDENTIALS environment
                 variable.
             custom_tags: '- (Optional) Custom tags to set on the secret managed at the destination.'
-            granularity: |-
-                - (Optional) Determines what level of information is synced as a distinct resource
-                at the destination. Supports secret-path and secret-key.
             name: '- (Required) Unique name of the GCP destination.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
                 The value should not contain leading or trailing forward slashes.
                 The namespace is always relative to the provider's configured namespace.
-            project_id: |-
-                - (Optional) The target project to manage secrets in. If set,
-                overrides the project ID derived from the service account JSON credentials or application
-                default credentials. The service account must be authorized
-                to perform Secret Manager actions in the target project.
             secret_name_template: |-
                 - (Optional) Template describing how to generate external secret names.
                 Supports a subset of the Go Template syntax.
@@ -7641,16 +7206,6 @@ resources:
                 - (Optional) Fine-grained or personal access token.
                 Can be omitted and directly provided to Vault using the GITHUB_ACCESS_TOKEN environment
                 variable.
-            app_name: |-
-                - (Optional) The user-defined name of the GitHub App configuration. This is a reference to the name used
-                on the new endpoint when configuring the GitHub app on the Vault Server. Can be modified.
-                Takes precedence over the access_token field.
-            granularity: |-
-                - (Optional) Determines what level of information is synced as a distinct resource
-                at the destination. Supports secret-path and secret-key.
-            installation_id: |-
-                -(Optional) The ID of the installation generated by GitHub when the app referenced by the app_name
-                was installed in the user’s GitHub account. Can be modified. Necessary if the app_name field is also provided.
             name: '- (Required) Unique name of the GitHub destination.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
@@ -7668,30 +7223,6 @@ resources:
                 - (Optional) Template describing how to generate external secret names.
                 Supports a subset of the Go Template syntax.
             type: '- The type of the secrets destination (gh).'
-        importStatements: []
-    vault_secrets_sync_github_apps:
-        subCategory: ""
-        description: Creates a GitHub App to synchronize secrets in Vault
-        name: vault_secrets_sync_github_apps
-        title: vault_secrets_sync_github_apps resource
-        examples:
-            - name: github-apps
-              manifest: |-
-                {
-                  "app_id": "${var.app_id}",
-                  "name": "gh-apps",
-                  "private_key": "${file(var.privatekey_file)}"
-                }
-              references:
-                app_id: var.app_id
-        argumentDocs:
-            app_id: '- (Required) The GitHub application ID.'
-            name: '- (Required) The user-defined name of the GitHub App configuration.'
-            namespace: |-
-                - (Optional) The namespace to provision the resource in.
-                The value should not contain leading or trailing forward slashes.
-                The namespace is always relative to the provider's configured namespace.
-            private_key: '- (Required) The content of a PEM formatted private key generated on GitHub for the app.'
         importStatements: []
     vault_secrets_sync_vercel_destination:
         subCategory: ""
@@ -7722,9 +7253,6 @@ resources:
             deployment_environments: |-
                 - (Required) Deployment environments where the environment variables
                 are available. Accepts development, preview and production.
-            granularity: |-
-                - (Optional) Determines what level of information is synced as a distinct resource
-                at the destination. Supports secret-path and secret-key.
             name: '- (Required) Unique name of the GitHub destination.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
@@ -7758,8 +7286,6 @@ resources:
         argumentDocs:
             backend: '- (Optional) The path where the SSH secret backend is mounted. Defaults to ''ssh'''
             generate_signing_key: '- (Optional) Whether Vault should generate the signing key pair internally. Defaults to true'
-            key_bits: '- (Optional) Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.'
-            key_type: '- (Optional) Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.'
             namespace: |-
                 - (Optional) The namespace to provision the resource in.
                 The value should not contain leading or trailing forward slashes.
@@ -7823,6 +7349,10 @@ resources:
                 - (Optional) Set of configuration blocks to define allowed
                 user key configuration, like key type and their lengths. Can be specified multiple times.
                 See
+            allowed_user_key_lengths: |-
+                - (Optional) Specifies a map of ssh key types and their expected sizes which
+                are allowed to be signed by the CA type.
+                Deprecated: use allowed_user_key_config instead
             allowed_users: '- (Optional) Specifies a comma-separated list of usernames that are to be allowed, only if certain usernames are to be allowed.'
             allowed_users_template: '- (Optional) Specifies if allowed_users can be declared using identity template policies. Non-templated users are also permitted.'
             backend: '- (Required) The path where the SSH secret backend is mounted.'
@@ -7869,10 +7399,6 @@ resources:
                   "token": "V0idfhi2iksSDU234ucdbi2nidsi..."
                 }
         argumentDocs:
-            address: |-
-                - (Optional) The address of the Terraform Cloud server, if using
-                Terraform Enterprise, provided as "protocol://host:port". The default is
-                https://app.terraform.io for Terraform Cloud.
             backend: '- (Optional) The unique location this backend should be mounted at. Must not begin or end with a /. Defaults to terraform.'
             default_lease_ttl_seconds: '- (Optional) The default TTL for credentials issued by this backend.'
             description: '- (Optional) A human-friendly description for this backend.'
@@ -8286,6 +7812,7 @@ resources:
         argumentDocs:
             aes128-gcm96: ', aes256-gcm96 and chacha20-poly1305, each key version will be a map of a single value id which is just a hash of the key''s metadata.'
             allow_plaintext_backup: '- (Optional) Enables taking backup of entire keyring in the plaintext format. Once set, this cannot be disabled.'
+            auto_rotate_interval: '- Replaced by auto_rotate_period.'
             auto_rotate_period: |-
                 - (Optional) Amount of seconds the key should live before being automatically rotated.
                 A value of 0 disables automatic rotation for the key.

--- a/config/vault/config.go
+++ b/config/vault/config.go
@@ -1,11 +1,31 @@
 package vault
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"github.com/crossplane/upjet/pkg/config"
+
+	"github.com/upbound/provider-vault/config/common"
+)
 
 // ConfigureNamespace configures the namespace resource.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("vault_namespace", func(r *config.Resource) {
 		r.Kind = "VaultNamespace"
 		r.ShortGroup = "vault"
+	})
+	p.AddResourceConfigurator("vault_pki_secret_backend_root_sign_intermediate", func(r *config.Resource) {
+		r.Kind = "SecretBackendRootSignIntermediate"
+		r.ShortGroup = "pki"
+		r.References["csr"] = config.Reference{
+			Type:      "SecretBackendIntermediateCertRequest",
+			Extractor: common.CsrExtractor,
+		}
+	})
+	p.AddResourceConfigurator("vault_pki_secret_backend_intermediate_set_signed", func(r *config.Resource) {
+		r.Kind = "SecretBackendIntermediateSetSigned"
+		r.ShortGroup = "pki"
+		r.References["certificate"] = config.Reference{
+			Type:      "SecretBackendRootSignIntermediate",
+			Extractor: common.CrtExtractor,
+		}
 	})
 }

--- a/examples-generated/aws/v1alpha1/authbackendclient.yaml
+++ b/examples-generated/aws/v1alpha1/authbackendclient.yaml
@@ -8,9 +8,17 @@ metadata:
   name: example
 spec:
   forProvider:
-    identityTokenAudience: <TOKEN_AUDIENCE>
-    identityTokenTtl: <TOKEN_TTL>
-    roleArn: <AWS_ROLE_ARN>
+    accessKeySecretRef:
+      key: example-key
+      name: example-secret
+      namespace: upbound-system
+    backendSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    secretKeySecretRef:
+      key: example-key
+      name: example-secret
+      namespace: upbound-system
 
 ---
 

--- a/examples-generated/azure/v1alpha1/authbackendconfig.yaml
+++ b/examples-generated/azure/v1alpha1/authbackendconfig.yaml
@@ -15,8 +15,11 @@ spec:
       key: example-key
       name: example-secret
       namespace: upbound-system
-    identityTokenAudience: <TOKEN_AUDIENCE>
-    identityTokenTtl: <TOKEN_TTL>
+    clientSecretSecretRef:
+      key: example-key
+      name: example-secret
+      namespace: upbound-system
+    resource: https://vault.hashicorp.com
     tenantIdSecretRef:
       key: example-key
       name: example-secret
@@ -34,5 +37,4 @@ metadata:
   name: example
 spec:
   forProvider:
-    identityTokenKey: example-key
     type: azure

--- a/examples-generated/azure/v1alpha1/secretbackend.yaml
+++ b/examples-generated/azure/v1alpha1/secretbackend.yaml
@@ -12,8 +12,11 @@ spec:
       key: example-key
       name: example-secret
       namespace: upbound-system
-    identityTokenAudience: <TOKEN_AUDIENCE>
-    identityTokenTtl: <TOKEN_TTL>
+    clientSecretSecretRef:
+      key: example-key
+      name: example-secret
+      namespace: upbound-system
+    environment: AzurePublicCloud
     subscriptionIdSecretRef:
       key: example-key
       name: example-secret
@@ -22,3 +25,4 @@ spec:
       key: example-key
       name: example-secret
       namespace: upbound-system
+    useMicrosoftGraphApi: true

--- a/examples-generated/gcp/v1alpha1/secretbackend.yaml
+++ b/examples-generated/gcp/v1alpha1/secretbackend.yaml
@@ -8,7 +8,7 @@ metadata:
   name: gcp
 spec:
   forProvider:
-    identityTokenAudience: <TOKEN_AUDIENCE>
-    identityTokenKey: example-key
-    identityTokenTtl: 1800
-    serviceAccountEmail: <SERVICE_ACCOUNT_EMAIL>
+    credentialsSecretRef:
+      key: attribute.credentials.json
+      name: example-secret
+      namespace: upbound-system

--- a/examples-generated/mongodbatlas/v1alpha1/secretbackend.yaml
+++ b/examples-generated/mongodbatlas/v1alpha1/secretbackend.yaml
@@ -8,9 +8,7 @@ metadata:
   name: config
 spec:
   forProvider:
-    mountSelector:
-      matchLabels:
-        testing.upbound.io/example-name: mongo
+    mount: vault_mount.mongo.path
     privateKey: privateKey
     publicKey: publicKey
 

--- a/examples-generated/mongodbatlas/v1alpha1/secretrole.yaml
+++ b/examples-generated/mongodbatlas/v1alpha1/secretrole.yaml
@@ -17,10 +17,8 @@ spec:
     name: tf-test-role
     organizationId: 7cf5a45a9ccf6400e60981b7
     projectId: 5cf5a45a9ccf6400e60981b6
-    projectRoles:
-    - GROUP_READ_ONLY
-    roles:
-    - ORG_READ_ONLY
+    projectRoles: GROUP_READ_ONLY
+    roles: ORG_READ_ONLY
     ttl: "60"
 
 ---
@@ -35,9 +33,7 @@ metadata:
   name: config
 spec:
   forProvider:
-    mountSelector:
-      matchLabels:
-        testing.upbound.io/example-name: mongo
+    mount: vault_mount.mongo.path
     privateKey: privateKey
     publicKey: publicKey
 

--- a/examples/pki/ca-chain.yaml
+++ b/examples/pki/ca-chain.yaml
@@ -1,0 +1,74 @@
+apiVersion: vault.vault.upbound.io/v1alpha1
+kind: Mount
+metadata:
+  name: example-pki
+spec:
+  forProvider:
+    path: example
+    type: pki
+    maxLeaseTtlSeconds: 315576000
+---
+apiVersion: vault.vault.upbound.io/v1alpha1
+kind: Mount
+metadata:
+  name: example-pki-int
+spec:
+  forProvider:
+    path: example-int
+    type: pki
+    maxLeaseTtlSeconds: 157788000
+---
+apiVersion: pki.vault.upbound.io/v1alpha1
+kind: SecretBackendRootCert
+metadata:
+  name: example-root-ca
+spec:
+  forProvider:
+    backend: example
+    commonName: Root CA
+    issuerName: Example
+    excludeCnFromSans: true
+    format: pem
+    keyBits: 4096
+    keyType: rsa
+    privateKeyFormat: der
+    ttl: 87660h
+    type: internal
+---
+apiVersion: pki.vault.upbound.io/v1alpha1
+kind: SecretBackendIntermediateCertRequest
+metadata:
+  name: example-intermediate-ca-csr
+spec:
+  forProvider:
+    backend: example-int
+    commonName: Intermediate CA
+    keyBits: 4096
+    keyType: rsa
+    privateKeyFormat: der
+    type: internal
+    excludeCnFromSans: true
+    format: pem
+---
+apiVersion: pki.vault.upbound.io/v1alpha1
+kind: SecretBackendRootSignIntermediate
+metadata:
+  name: example-intermediate-ca-sign
+spec:
+  forProvider:
+    backend: example
+    issuerRef: Example
+    commonName: Intermediate CA
+    csrRef:
+      name: intermediate-ca-csr
+    ttl: 43830h
+---
+apiVersion: pki.vault.upbound.io/v1alpha1
+kind: SecretBackendIntermediateSetSigned
+metadata:
+  name: example-intermediate-ca-set-signed
+spec:
+  forProvider:
+    backend: example-int
+    certificateRef:
+      name: intermediate-ca-sign

--- a/package/crds/ad.vault.upbound.io_secretbackends.yaml
+++ b/package/crds/ad.vault.upbound.io_secretbackends.yaml
@@ -241,7 +241,7 @@ spec:
                     type: string
                   passwordPolicy:
                     description: |-
-                      Name of the password policy to use to generate passwords.
+                      1.11+
                       Name of the password policy to use to generate passwords.
                     type: string
                   requestTimeout:
@@ -491,7 +491,7 @@ spec:
                     type: string
                   passwordPolicy:
                     description: |-
-                      Name of the password policy to use to generate passwords.
+                      1.11+
                       Name of the password policy to use to generate passwords.
                     type: string
                   requestTimeout:
@@ -855,7 +855,7 @@ spec:
                     type: string
                   passwordPolicy:
                     description: |-
-                      Name of the password policy to use to generate passwords.
+                      1.11+
                       Name of the password policy to use to generate passwords.
                     type: string
                   requestTimeout:

--- a/package/crds/aws.vault.upbound.io_authbackendclients.yaml
+++ b/package/crds/aws.vault.upbound.io_authbackendclients.yaml
@@ -76,7 +76,7 @@ spec:
                   accessKeySecretRef:
                     description: |-
                       The AWS access key that Vault should use for the
-                      auth backend. Mutually exclusive with identity_token_audience.
+                      auth backend.
                       AWS Access key with permissions to query AWS APIs.
                     properties:
                       key:
@@ -193,22 +193,14 @@ spec:
                       The value to require in the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity requests that are used in the iam auth method.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Mutually exclusive with access_key.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   maxRetries:
-                    description: |-
-                      Number of max retries the client should use for recoverable errors.
-                      The default -1 falls back to the AWS SDK's default behavior.
-                      Number of max retries the client should use for recoverable errors.
+                    description: Number of max retries the client should use for recoverable
+                      errors.
                     type: number
                   namespace:
                     description: |-
@@ -219,10 +211,7 @@ spec:
                       Target namespace. (requires Enterprise)
                     type: string
                   roleArn:
-                    description: |-
-                      Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      Role ARN to assume for plugin identity token federation.
+                    description: Role ARN to assume for plugin identity token federation.
                     type: string
                   secretKeySecretRef:
                     description: |-
@@ -282,7 +271,7 @@ spec:
                   accessKeySecretRef:
                     description: |-
                       The AWS access key that Vault should use for the
-                      auth backend. Mutually exclusive with identity_token_audience.
+                      auth backend.
                       AWS Access key with permissions to query AWS APIs.
                     properties:
                       key:
@@ -399,22 +388,14 @@ spec:
                       The value to require in the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity requests that are used in the iam auth method.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Mutually exclusive with access_key.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   maxRetries:
-                    description: |-
-                      Number of max retries the client should use for recoverable errors.
-                      The default -1 falls back to the AWS SDK's default behavior.
-                      Number of max retries the client should use for recoverable errors.
+                    description: Number of max retries the client should use for recoverable
+                      errors.
                     type: number
                   namespace:
                     description: |-
@@ -425,10 +406,7 @@ spec:
                       Target namespace. (requires Enterprise)
                     type: string
                   roleArn:
-                    description: |-
-                      Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      Role ARN to assume for plugin identity token federation.
+                    description: Role ARN to assume for plugin identity token federation.
                     type: string
                   secretKeySecretRef:
                     description: |-
@@ -672,22 +650,14 @@ spec:
                   id:
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Mutually exclusive with access_key.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   maxRetries:
-                    description: |-
-                      Number of max retries the client should use for recoverable errors.
-                      The default -1 falls back to the AWS SDK's default behavior.
-                      Number of max retries the client should use for recoverable errors.
+                    description: Number of max retries the client should use for recoverable
+                      errors.
                     type: number
                   namespace:
                     description: |-
@@ -698,10 +668,7 @@ spec:
                       Target namespace. (requires Enterprise)
                     type: string
                   roleArn:
-                    description: |-
-                      Role ARN to assume for plugin identity token federation. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      Role ARN to assume for plugin identity token federation.
+                    description: Role ARN to assume for plugin identity token federation.
                     type: string
                   stsEndpoint:
                     description: |-

--- a/package/crds/aws.vault.upbound.io_secretbackendroles.yaml
+++ b/package/crds/aws.vault.upbound.io_secretbackendroles.yaml
@@ -170,10 +170,7 @@ spec:
                       The default TTL in seconds for STS credentials. When a TTL is not specified when STS credentials are requested, and a default TTL is specified on the role, then this default TTL will be used. Valid only when credential_type is one of assumed_role or federation_token.
                     type: number
                   externalId:
-                    description: |-
-                      External ID to set for assume role creds.
-                      Valid only when credential_type is set to assumed_role.
-                      External ID to set for assume role creds.
+                    description: External ID to set for assume role creds.
                     type: string
                   iamGroups:
                     description: |-
@@ -191,10 +188,8 @@ spec:
                   iamTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs
-                      to be used as tags for any IAM user that is created by this role.
-                      A map of strings representing key/value pairs used as tags for any IAM user created by this role.
+                    description: A map of strings representing key/value pairs used
+                      as tags for any IAM user created by this role.
                     type: object
                     x-kubernetes-map-type: granular
                   maxStsTtl:
@@ -262,11 +257,7 @@ spec:
                   sessionTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs to be set
-                      during assume role creds creation. Valid only when credential_type is set to
-                      assumed_role.
-                      Session tags to be set for assume role creds created.
+                    description: Session tags to be set for assume role creds created.
                     type: object
                     x-kubernetes-map-type: granular
                   userPath:
@@ -386,10 +377,7 @@ spec:
                       The default TTL in seconds for STS credentials. When a TTL is not specified when STS credentials are requested, and a default TTL is specified on the role, then this default TTL will be used. Valid only when credential_type is one of assumed_role or federation_token.
                     type: number
                   externalId:
-                    description: |-
-                      External ID to set for assume role creds.
-                      Valid only when credential_type is set to assumed_role.
-                      External ID to set for assume role creds.
+                    description: External ID to set for assume role creds.
                     type: string
                   iamGroups:
                     description: |-
@@ -407,10 +395,8 @@ spec:
                   iamTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs
-                      to be used as tags for any IAM user that is created by this role.
-                      A map of strings representing key/value pairs used as tags for any IAM user created by this role.
+                    description: A map of strings representing key/value pairs used
+                      as tags for any IAM user created by this role.
                     type: object
                     x-kubernetes-map-type: granular
                   maxStsTtl:
@@ -478,11 +464,7 @@ spec:
                   sessionTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs to be set
-                      during assume role creds creation. Valid only when credential_type is set to
-                      assumed_role.
-                      Session tags to be set for assume role creds created.
+                    description: Session tags to be set for assume role creds created.
                     type: object
                     x-kubernetes-map-type: granular
                   userPath:
@@ -696,10 +678,7 @@ spec:
                       The default TTL in seconds for STS credentials. When a TTL is not specified when STS credentials are requested, and a default TTL is specified on the role, then this default TTL will be used. Valid only when credential_type is one of assumed_role or federation_token.
                     type: number
                   externalId:
-                    description: |-
-                      External ID to set for assume role creds.
-                      Valid only when credential_type is set to assumed_role.
-                      External ID to set for assume role creds.
+                    description: External ID to set for assume role creds.
                     type: string
                   iamGroups:
                     description: |-
@@ -717,10 +696,8 @@ spec:
                   iamTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs
-                      to be used as tags for any IAM user that is created by this role.
-                      A map of strings representing key/value pairs used as tags for any IAM user created by this role.
+                    description: A map of strings representing key/value pairs used
+                      as tags for any IAM user created by this role.
                     type: object
                     x-kubernetes-map-type: granular
                   id:
@@ -790,11 +767,7 @@ spec:
                   sessionTags:
                     additionalProperties:
                       type: string
-                    description: |-
-                      A map of strings representing key/value pairs to be set
-                      during assume role creds creation. Valid only when credential_type is set to
-                      assumed_role.
-                      Session tags to be set for assume role creds created.
+                    description: Session tags to be set for assume role creds created.
                     type: object
                     x-kubernetes-map-type: granular
                   userPath:

--- a/package/crds/azure.vault.upbound.io_authbackendconfigs.yaml
+++ b/package/crds/azure.vault.upbound.io_authbackendconfigs.yaml
@@ -201,17 +201,10 @@ spec:
                       The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds.
-                      Defaults to 1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-
@@ -389,17 +382,10 @@ spec:
                       The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds.
-                      Defaults to 1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-
@@ -634,17 +620,10 @@ spec:
                   id:
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds.
-                      Defaults to 1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-

--- a/package/crds/azure.vault.upbound.io_secretbackends.yaml
+++ b/package/crds/azure.vault.upbound.io_secretbackends.yaml
@@ -126,22 +126,13 @@ spec:
                       The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-
@@ -268,22 +259,13 @@ spec:
                       The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-
@@ -543,22 +525,13 @@ spec:
                   id:
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The audience claim value.
+                    description: The audience claim value.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing identity tokens. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
-                      Available only for Vault Enterprise
-                      The TTL of generated identity tokens in seconds.
+                    description: The TTL of generated identity tokens in seconds.
                     type: number
                   namespace:
                     description: |-

--- a/package/crds/gcp.vault.upbound.io_secretbackends.yaml
+++ b/package/crds/gcp.vault.upbound.io_secretbackends.yaml
@@ -110,24 +110,13 @@ spec:
                       If set, opts out of mount migration on path updates.
                     type: boolean
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity
-                      tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-                      Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The audience claim value for plugin identity tokens.
+                    description: The audience claim value for plugin identity tokens.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin identity
-                      tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated tokens. Defaults to
-                      1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The TTL of generated tokens.
+                    description: The TTL of generated tokens.
                     type: number
                   local:
                     description: |-
@@ -155,10 +144,8 @@ spec:
                       Path to mount the backend at.
                     type: string
                   serviceAccountEmail:
-                    description: |-
-                      –  Service Account to impersonate for plugin workload identity federation.
-                      Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      Service Account to impersonate for plugin workload identity federation.
+                    description: Service Account to impersonate for plugin workload
+                      identity federation.
                     type: string
                 type: object
               initProvider:
@@ -211,24 +198,13 @@ spec:
                       If set, opts out of mount migration on path updates.
                     type: boolean
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity
-                      tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-                      Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The audience claim value for plugin identity tokens.
+                    description: The audience claim value for plugin identity tokens.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin identity
-                      tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated tokens. Defaults to
-                      1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The TTL of generated tokens.
+                    description: The TTL of generated tokens.
                     type: number
                   local:
                     description: |-
@@ -256,10 +232,8 @@ spec:
                       Path to mount the backend at.
                     type: string
                   serviceAccountEmail:
-                    description: |-
-                      –  Service Account to impersonate for plugin workload identity federation.
-                      Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      Service Account to impersonate for plugin workload identity federation.
+                    description: Service Account to impersonate for plugin workload
+                      identity federation.
                     type: string
                 type: object
               managementPolicies:
@@ -435,9 +409,7 @@ spec:
               atProvider:
                 properties:
                   accessor:
-                    description: |-
-                      The accessor of the created GCP mount.
-                      Accessor of the created GCP mount.
+                    description: Accessor of the created GCP mount.
                     type: string
                   defaultLeaseTtlSeconds:
                     description: |-
@@ -459,24 +431,13 @@ spec:
                   id:
                     type: string
                   identityTokenAudience:
-                    description: |-
-                      The audience claim value for plugin identity
-                      tokens. Must match an allowed audience configured for the target Workload Identity Pool.
-                      Mutually exclusive with credentials.  Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The audience claim value for plugin identity tokens.
+                    description: The audience claim value for plugin identity tokens.
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin identity
-                      tokens. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The key to use for signing identity tokens.
+                    description: The key to use for signing identity tokens.
                     type: string
                   identityTokenTtl:
-                    description: |-
-                      The TTL of generated tokens. Defaults to
-                      1 hour. Uses duration format strings.
-                      Requires Vault 1.17+. Available only for Vault Enterprise.
-                      The TTL of generated tokens.
+                    description: The TTL of generated tokens.
                     type: number
                   local:
                     description: |-
@@ -504,10 +465,8 @@ spec:
                       Path to mount the backend at.
                     type: string
                   serviceAccountEmail:
-                    description: |-
-                      –  Service Account to impersonate for plugin workload identity federation.
-                      Required with identity_token_audience. Requires Vault 1.17+. Available only for Vault Enterprise.
-                      Service Account to impersonate for plugin workload identity federation.
+                    description: Service Account to impersonate for plugin workload
+                      identity federation.
                     type: string
                 type: object
               conditions:

--- a/package/crds/identity.vault.upbound.io_oidcclients.yaml
+++ b/package/crds/identity.vault.upbound.io_oidcclients.yaml
@@ -389,9 +389,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   clientId:
-                    description: |-
-                      The Client ID returned by Vault.
-                      The Client ID from Vault.
+                    description: The Client ID from Vault.
                     type: string
                   clientType:
                     description: |-

--- a/package/crds/jwt.vault.upbound.io_authbackendroles.yaml
+++ b/package/crds/jwt.vault.upbound.io_authbackendroles.yaml
@@ -164,7 +164,9 @@ spec:
                     type: object
                   boundAudiences:
                     description: |-
-                      List of aud claims to match against. Any match is sufficient.
+                      (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+                      or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+                      Any match is sufficient.
                       List of aud claims to match against. Any match is sufficient.
                     items:
                       type: string
@@ -216,7 +218,7 @@ spec:
                   expirationLeeway:
                     description: |-
                       The amount of leeway to add to expiration (exp) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number
@@ -245,7 +247,7 @@ spec:
                   notBeforeLeeway:
                     description: |-
                       The amount of leeway to add to not before (nbf) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number
@@ -463,7 +465,9 @@ spec:
                     type: object
                   boundAudiences:
                     description: |-
-                      List of aud claims to match against. Any match is sufficient.
+                      (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+                      or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+                      Any match is sufficient.
                       List of aud claims to match against. Any match is sufficient.
                     items:
                       type: string
@@ -515,7 +519,7 @@ spec:
                   expirationLeeway:
                     description: |-
                       The amount of leeway to add to expiration (exp) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number
@@ -544,7 +548,7 @@ spec:
                   notBeforeLeeway:
                     description: |-
                       The amount of leeway to add to not before (nbf) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number
@@ -856,7 +860,9 @@ spec:
                     type: string
                   boundAudiences:
                     description: |-
-                      List of aud claims to match against. Any match is sufficient.
+                      (For "jwt" roles, at least one of bound_audiences, bound_subject, bound_claims
+                      or token_bound_cidrs is required. Optional for "oidc" roles.) List of aud claims to match against.
+                      Any match is sufficient.
                       List of aud claims to match against. Any match is sufficient.
                     items:
                       type: string
@@ -908,7 +914,7 @@ spec:
                   expirationLeeway:
                     description: |-
                       The amount of leeway to add to expiration (exp) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number
@@ -939,7 +945,7 @@ spec:
                   notBeforeLeeway:
                     description: |-
                       The amount of leeway to add to not before (nbf) claims to account for
-                      clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1.
+                      clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1.
                       Only applicable with "jwt" roles.
                       The amount of leeway to add to not before (nbf) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.
                     type: number

--- a/package/crds/kubernetes.vault.upbound.io_secretbackendroles.yaml
+++ b/package/crds/kubernetes.vault.upbound.io_secretbackendroles.yaml
@@ -74,18 +74,15 @@ spec:
               forProvider:
                 properties:
                   allowedKubernetesNamespaceSelector:
-                    description: |-
-                      A label selector for Kubernetes namespaces
-                      in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-                      of type LabelSelector.
-                      If set with allowed_kubernetes_namespace, the conditions are ORed.
-                      A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
+                    description: A label selector for Kubernetes namespaces in which
+                      credentials can begenerated. Accepts either a JSON or YAML object.
+                      The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`,
+                      the conditions are `OR`ed.
                     type: string
                   allowedKubernetesNamespaces:
                     description: |-
                       The list of Kubernetes namespaces this role
-                      can generate credentials for. If set to * all namespaces are allowed. If set with
-                      allowed_kubernetes_namespace_selector, the conditions are ORed.
+                      can generate credentials for. If set to * all namespaces are allowed.
                       The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
                     items:
                       type: string
@@ -263,18 +260,15 @@ spec:
                   autoscaler.
                 properties:
                   allowedKubernetesNamespaceSelector:
-                    description: |-
-                      A label selector for Kubernetes namespaces
-                      in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-                      of type LabelSelector.
-                      If set with allowed_kubernetes_namespace, the conditions are ORed.
-                      A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
+                    description: A label selector for Kubernetes namespaces in which
+                      credentials can begenerated. Accepts either a JSON or YAML object.
+                      The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`,
+                      the conditions are `OR`ed.
                     type: string
                   allowedKubernetesNamespaces:
                     description: |-
                       The list of Kubernetes namespaces this role
-                      can generate credentials for. If set to * all namespaces are allowed. If set with
-                      allowed_kubernetes_namespace_selector, the conditions are ORed.
+                      can generate credentials for. If set to * all namespaces are allowed.
                       The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
                     items:
                       type: string
@@ -616,18 +610,15 @@ spec:
               atProvider:
                 properties:
                   allowedKubernetesNamespaceSelector:
-                    description: |-
-                      A label selector for Kubernetes namespaces
-                      in which credentials can be generated. Accepts either a JSON or YAML object. The value should be
-                      of type LabelSelector.
-                      If set with allowed_kubernetes_namespace, the conditions are ORed.
-                      A label selector for Kubernetes namespaces in which credentials can begenerated. Accepts either a JSON or YAML object. The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.
+                    description: A label selector for Kubernetes namespaces in which
+                      credentials can begenerated. Accepts either a JSON or YAML object.
+                      The value should be of typeLabelSelector. If set with `allowed_kubernetes_namespace`,
+                      the conditions are `OR`ed.
                     type: string
                   allowedKubernetesNamespaces:
                     description: |-
                       The list of Kubernetes namespaces this role
-                      can generate credentials for. If set to * all namespaces are allowed. If set with
-                      allowed_kubernetes_namespace_selector, the conditions are ORed.
+                      can generate credentials for. If set to * all namespaces are allowed.
                       The list of Kubernetes namespaces this role can generate credentials for. If set to '*' all namespaces are allowed. If set with`allowed_kubernetes_namespace_selector`, the conditions are `OR`ed.
                     items:
                       type: string

--- a/package/crds/mongodbatlas.vault.upbound.io_secretbackends.yaml
+++ b/package/crds/mongodbatlas.vault.upbound.io_secretbackends.yaml
@@ -78,80 +78,6 @@ spec:
                       Path where the MongoDB Atlas Secrets Engine is mounted.
                       Path where MongoDB Atlas secret backend is mounted
                     type: string
-                  mountRef:
-                    description: Reference to a Mount in vault to populate mount.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  mountSelector:
-                    description: Selector for a Mount in vault to populate mount.
-                    properties:
-                      matchControllerRef:
-                        description: |-
-                          MatchControllerRef ensures an object with the same controller reference
-                          as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
                   namespace:
                     description: |-
                       The namespace to provision the resource in.
@@ -189,80 +115,6 @@ spec:
                       Path where the MongoDB Atlas Secrets Engine is mounted.
                       Path where MongoDB Atlas secret backend is mounted
                     type: string
-                  mountRef:
-                    description: Reference to a Mount in vault to populate mount.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  mountSelector:
-                    description: Selector for a Mount in vault to populate mount.
-                    properties:
-                      matchControllerRef:
-                        description: |-
-                          MatchControllerRef ensures an object with the same controller reference
-                          as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
                   namespace:
                     description: |-
                       The namespace to provision the resource in.
@@ -450,6 +302,10 @@ spec:
             - forProvider
             type: object
             x-kubernetes-validations:
+            - message: spec.forProvider.mount is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.mount)
+                || (has(self.initProvider) && has(self.initProvider.mount))'
             - message: spec.forProvider.privateKey is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.privateKey)

--- a/package/crds/mongodbatlas.vault.upbound.io_secretroles.yaml
+++ b/package/crds/mongodbatlas.vault.upbound.io_secretroles.yaml
@@ -198,14 +198,14 @@ spec:
                     type: string
                   projectRoles:
                     description: |-
-                      Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+                      Roles assigned when an org API key is assigned to a project API key.
                       Roles assigned when an org API key is assigned to a project API key
                     items:
                       type: string
                     type: array
                   roles:
                     description: |-
-                      List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+                      List of roles that the API Key needs to have.
                       List of roles that the API Key needs to have
                     items:
                       type: string
@@ -354,14 +354,14 @@ spec:
                     type: string
                   projectRoles:
                     description: |-
-                      Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+                      Roles assigned when an org API key is assigned to a project API key.
                       Roles assigned when an org API key is assigned to a project API key
                     items:
                       type: string
                     type: array
                   roles:
                     description: |-
-                      List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+                      List of roles that the API Key needs to have.
                       List of roles that the API Key needs to have
                     items:
                       type: string
@@ -606,14 +606,14 @@ spec:
                     type: string
                   projectRoles:
                     description: |-
-                      Roles assigned when an org API key is assigned to a project API key. Possible values are GROUP_CLUSTER_MANAGER, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_OWNER and GROUP_READ_ONLY.
+                      Roles assigned when an org API key is assigned to a project API key.
                       Roles assigned when an org API key is assigned to a project API key
                     items:
                       type: string
                     type: array
                   roles:
                     description: |-
-                      List of roles that the API Key needs to have. Possible values are ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN and ORG_READ_ONLY.
+                      List of roles that the API Key needs to have.
                       List of roles that the API Key needs to have
                     items:
                       type: string

--- a/package/crds/pki.vault.upbound.io_secretbackendconfigurls.yaml
+++ b/package/crds/pki.vault.upbound.io_secretbackendconfigurls.yaml
@@ -161,9 +161,7 @@ spec:
                       type: string
                     type: array
                   enableTemplating:
-                    description: |-
-                      Specifies that templating of AIA fields is allowed.
-                      Specifies that templating of AIA fields is allowed.
+                    description: Specifies that templating of AIA fields is allowed.
                     type: boolean
                   issuingCertificates:
                     description: |-
@@ -288,9 +286,7 @@ spec:
                       type: string
                     type: array
                   enableTemplating:
-                    description: |-
-                      Specifies that templating of AIA fields is allowed.
-                      Specifies that templating of AIA fields is allowed.
+                    description: Specifies that templating of AIA fields is allowed.
                     type: boolean
                   issuingCertificates:
                     description: |-
@@ -501,9 +497,7 @@ spec:
                       type: string
                     type: array
                   enableTemplating:
-                    description: |-
-                      Specifies that templating of AIA fields is allowed.
-                      Specifies that templating of AIA fields is allowed.
+                    description: Specifies that templating of AIA fields is allowed.
                     type: boolean
                   id:
                     type: string

--- a/package/crds/pki.vault.upbound.io_secretbackendintermediatesetsigneds.yaml
+++ b/package/crds/pki.vault.upbound.io_secretbackendintermediatesetsigneds.yaml
@@ -162,7 +162,7 @@ spec:
                     type: string
                   certificateRef:
                     description: Reference to a SecretBackendRootSignIntermediate
-                      in pki to populate certificate.
+                      to populate certificate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -197,7 +197,7 @@ spec:
                     type: object
                   certificateSelector:
                     description: Selector for a SecretBackendRootSignIntermediate
-                      in pki to populate certificate.
+                      to populate certificate.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -346,7 +346,7 @@ spec:
                     type: string
                   certificateRef:
                     description: Reference to a SecretBackendRootSignIntermediate
-                      in pki to populate certificate.
+                      to populate certificate.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -381,7 +381,7 @@ spec:
                     type: object
                   certificateSelector:
                     description: Selector for a SecretBackendRootSignIntermediate
-                      in pki to populate certificate.
+                      to populate certificate.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/pki.vault.upbound.io_secretbackendrootsignintermediates.yaml
+++ b/package/crds/pki.vault.upbound.io_secretbackendrootsignintermediates.yaml
@@ -91,6 +91,82 @@ spec:
                   csr:
                     description: The CSR.
                     type: string
+                  csrRef:
+                    description: Reference to a SecretBackendIntermediateCertRequest
+                      to populate csr.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  csrSelector:
+                    description: Selector for a SecretBackendIntermediateCertRequest
+                      to populate csr.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   excludeCnFromSans:
                     description: Flag to exclude CN from SANs.
                     type: boolean
@@ -186,6 +262,82 @@ spec:
                   csr:
                     description: The CSR.
                     type: string
+                  csrRef:
+                    description: Reference to a SecretBackendIntermediateCertRequest
+                      to populate csr.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  csrSelector:
+                    description: Selector for a SecretBackendIntermediateCertRequest
+                      to populate csr.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   excludeCnFromSans:
                     description: Flag to exclude CN from SANs.
                     type: boolean
@@ -427,10 +579,6 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.commonName)
                 || (has(self.initProvider) && has(self.initProvider.commonName))'
-            - message: spec.forProvider.csr is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.csr)
-                || (has(self.initProvider) && has(self.initProvider.csr))'
           status:
             description: SecretBackendRootSignIntermediateStatus defines the observed
               state of SecretBackendRootSignIntermediate.

--- a/package/crds/quota.vault.upbound.io_leasecounts.yaml
+++ b/package/crds/quota.vault.upbound.io_leasecounts.yaml
@@ -74,9 +74,11 @@ spec:
               forProvider:
                 properties:
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   maxLeases:
                     description: |-
@@ -127,9 +129,11 @@ spec:
                   autoscaler.
                 properties:
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   maxLeases:
                     description: |-
@@ -350,9 +354,11 @@ spec:
                   id:
                     type: string
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   maxLeases:
                     description: |-

--- a/package/crds/quota.vault.upbound.io_ratelimits.yaml
+++ b/package/crds/quota.vault.upbound.io_ratelimits.yaml
@@ -80,9 +80,11 @@ spec:
                       If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
                     type: number
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   interval:
                     description: |-
@@ -144,9 +146,11 @@ spec:
                       If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
                     type: number
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   interval:
                     description: |-
@@ -378,9 +382,11 @@ spec:
                   id:
                     type: string
                   inheritable:
-                    description: |-
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
-                      If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+                    description: If set to true on a quota where path is set to a
+                      namespace, the same quota will be cumulatively applied to all
+                      child namespace. The inheritable parameter cannot be set to
+                      true if the path does not specify a namespace. Only the quotas
+                      associated with the root namespace are inheritable by default.
                     type: boolean
                   interval:
                     description: |-

--- a/package/crds/ssh.vault.upbound.io_secretbackendcas.yaml
+++ b/package/crds/ssh.vault.upbound.io_secretbackendcas.yaml
@@ -158,14 +158,12 @@ spec:
                       Whether Vault should generate the signing key pair internally.
                     type: boolean
                   keyBits:
-                    description: |-
-                      Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key bits for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: number
                   keyType:
-                    description: |-
-                      Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key type for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: string
                   namespace:
                     description: |-
@@ -298,14 +296,12 @@ spec:
                       Whether Vault should generate the signing key pair internally.
                     type: boolean
                   keyBits:
-                    description: |-
-                      Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key bits for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: number
                   keyType:
-                    description: |-
-                      Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key type for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: string
                   namespace:
                     description: |-
@@ -525,14 +521,12 @@ spec:
                   id:
                     type: string
                   keyBits:
-                    description: |-
-                      Specifies the desired key bits for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key bits for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: number
                   keyType:
-                    description: |-
-                      Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.
-                      Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
+                    description: Specifies the desired key type for the generated
+                      SSH CA key when `generate_signing_key` is set to `true`.
                     type: string
                   namespace:
                     description: |-

--- a/package/crds/terraform.vault.upbound.io_cloudsecretbackends.yaml
+++ b/package/crds/terraform.vault.upbound.io_cloudsecretbackends.yaml
@@ -74,9 +74,7 @@ spec:
               forProvider:
                 properties:
                   address:
-                    description: |-
-                      The default is
-                      https://app.0.0.1:8500".
+                    description: 0.0.1:8500".
                     type: string
                   backend:
                     description: The unique location this backend should be mounted
@@ -147,9 +145,7 @@ spec:
                   autoscaler.
                 properties:
                   address:
-                    description: |-
-                      The default is
-                      https://app.0.0.1:8500".
+                    description: 0.0.1:8500".
                     type: string
                   backend:
                     description: The unique location this backend should be mounted
@@ -379,9 +375,7 @@ spec:
               atProvider:
                 properties:
                   address:
-                    description: |-
-                      The default is
-                      https://app.0.0.1:8500".
+                    description: 0.0.1:8500".
                     type: string
                   backend:
                     description: The unique location this backend should be mounted

--- a/package/crds/vault.vault.upbound.io_mounts.yaml
+++ b/package/crds/vault.vault.upbound.io_mounts.yaml
@@ -82,10 +82,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   allowedResponseHeaders:
-                    description: |-
-                      List of headers to allow, allowing a plugin to include
-                      them in the response.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -109,10 +107,8 @@ spec:
                       Default lease duration for tokens and secrets in seconds
                     type: number
                   delegatedAuthAccessors:
-                    description: |-
-                      List of allowed authentication mount accessors the
-                      backend can request delegated authentication for.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -127,16 +123,12 @@ spec:
                       Enable the secrets engine to access Vault's external entropy source
                     type: boolean
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin workload identity tokens. If
-                      not provided, this will default to Vault's OIDC default key.
-                      The key to use for signing plugin workload identity tokens
+                    description: The key to use for signing plugin workload identity
+                      tokens
                     type: string
                   listingVisibility:
-                    description: |-
-                      Specifies whether to show this mount in the UI-specific
-                      listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
-                      Specifies whether to show this mount in the UI-specific listing endpoint
+                    description: Specifies whether to show this mount in the UI-specific
+                      listing endpoint
                     type: string
                   local:
                     description: |-
@@ -165,10 +157,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   passthroughRequestHeaders:
-                    description: |-
-                      List of headers to allow and pass from the request to
-                      the plugin.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -178,11 +168,8 @@ spec:
                       Where the secret backend will be mounted
                     type: string
                   pluginVersion:
-                    description: |-
-                      Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-                      If unspecified, the server will select any matching unversioned plugin that may have been
-                      registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
-                      Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
+                    description: Specifies the semantic version of the plugin to use,
+                      e.g. 'v1.0.0'
                     type: string
                   sealWrap:
                     description: |-
@@ -217,10 +204,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   allowedResponseHeaders:
-                    description: |-
-                      List of headers to allow, allowing a plugin to include
-                      them in the response.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -244,10 +229,8 @@ spec:
                       Default lease duration for tokens and secrets in seconds
                     type: number
                   delegatedAuthAccessors:
-                    description: |-
-                      List of allowed authentication mount accessors the
-                      backend can request delegated authentication for.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -262,16 +245,12 @@ spec:
                       Enable the secrets engine to access Vault's external entropy source
                     type: boolean
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin workload identity tokens. If
-                      not provided, this will default to Vault's OIDC default key.
-                      The key to use for signing plugin workload identity tokens
+                    description: The key to use for signing plugin workload identity
+                      tokens
                     type: string
                   listingVisibility:
-                    description: |-
-                      Specifies whether to show this mount in the UI-specific
-                      listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
-                      Specifies whether to show this mount in the UI-specific listing endpoint
+                    description: Specifies whether to show this mount in the UI-specific
+                      listing endpoint
                     type: string
                   local:
                     description: |-
@@ -300,10 +279,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   passthroughRequestHeaders:
-                    description: |-
-                      List of headers to allow and pass from the request to
-                      the plugin.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -313,11 +290,8 @@ spec:
                       Where the secret backend will be mounted
                     type: string
                   pluginVersion:
-                    description: |-
-                      Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-                      If unspecified, the server will select any matching unversioned plugin that may have been
-                      registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
-                      Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
+                    description: Specifies the semantic version of the plugin to use,
+                      e.g. 'v1.0.0'
                     type: string
                   sealWrap:
                     description: |-
@@ -525,10 +499,8 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   allowedResponseHeaders:
-                    description: |-
-                      List of headers to allow, allowing a plugin to include
-                      them in the response.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -552,10 +524,8 @@ spec:
                       Default lease duration for tokens and secrets in seconds
                     type: number
                   delegatedAuthAccessors:
-                    description: |-
-                      List of allowed authentication mount accessors the
-                      backend can request delegated authentication for.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -572,16 +542,12 @@ spec:
                   id:
                     type: string
                   identityTokenKey:
-                    description: |-
-                      The key to use for signing plugin workload identity tokens. If
-                      not provided, this will default to Vault's OIDC default key.
-                      The key to use for signing plugin workload identity tokens
+                    description: The key to use for signing plugin workload identity
+                      tokens
                     type: string
                   listingVisibility:
-                    description: |-
-                      Specifies whether to show this mount in the UI-specific
-                      listing endpoint. Valid values are unauth or hidden. If not set, behaves like hidden.
-                      Specifies whether to show this mount in the UI-specific listing endpoint
+                    description: Specifies whether to show this mount in the UI-specific
+                      listing endpoint
                     type: string
                   local:
                     description: |-
@@ -610,10 +576,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   passthroughRequestHeaders:
-                    description: |-
-                      List of headers to allow and pass from the request to
-                      the plugin.
-                      List of headers to allow and pass from the request to the plugin
+                    description: List of headers to allow and pass from the request
+                      to the plugin
                     items:
                       type: string
                     type: array
@@ -623,11 +587,8 @@ spec:
                       Where the secret backend will be mounted
                     type: string
                   pluginVersion:
-                    description: |-
-                      Specifies the semantic version of the plugin to use, e.g. "v1.0.0".
-                      If unspecified, the server will select any matching unversioned plugin that may have been
-                      registered, the latest versioned plugin registered, or a built-in plugin in that order of precedence.
-                      Specifies the semantic version of the plugin to use, e.g. 'v1.0.0'
+                    description: Specifies the semantic version of the plugin to use,
+                      e.g. 'v1.0.0'
                     type: string
                   sealWrap:
                     description: |-


### PR DESCRIPTION
### Description of your changes
This change introduces a new reference parameter for the SecretBackendRootSignIntermediate and SecretBackendIntermediateSetSigned objects which enables the creation of a CA certificate chain using the HashiCorp Vault provider.

For the SecretBackendRootSignIntermediate object, the new parameter allows to reference a SecretBackendIntermediateCertRequest object, from which the "csr" parameter is fetched.

For the SecretBackendIntermediateSetSigned object, the new parameter allows to reference a SecretBackendIntermediateSetSigned object, from which the "certificate" parameter is fetched.

The MR also includes an example of creating a CA chain using the new reference parameters.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

See #40

[contribution process]: https://git.io/fj2m9
