### PR TITLE
feat: add vault kubernetes service account auth

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -125,7 +125,7 @@ type ProviderHeaders struct {
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
 	// Source of the provider credentials.
-	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
+	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem;Kubernetes
 	Source xpv1.CredentialsSource `json:"source"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
-// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != '')",message="role is required when credentials.source is Kubernetes"
+// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (has(self.role) && self.role != '')",message="role is required when credentials.source is Kubernetes"
 type ProviderConfigSpec struct {
 	// Required origin URL of the Vault server.
 	// This is a URL with a scheme, a hostname

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -90,6 +90,10 @@ type ProviderConfigSpec struct {
 	// +optional
 	Headers ProviderHeaders `json:"headers,omitempty"`
 
+	// Name of the role against which to login.
+	// +optional
+	Role *string `json:"role,omitempty"`
+
 	// Credentials required to authenticate to this provider.
 	// There are many options to authenticate. They include
 	// - token - (Optional) Vault token that will be used

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -11,6 +11,7 @@ import (
 )
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
+// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != '')",message="role is requires when credentials.source is Kubernetes"
 type ProviderConfigSpec struct {
 	// Required origin URL of the Vault server.
 	// This is a URL with a scheme, a hostname

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
-// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (has(self.role) && self.role != '')",message="role is required when credentials.source is Kubernetes"
+// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (has(self.role) && self.role != \"\")",message="role is required when credentials.source is Kubernetes"
 type ProviderConfigSpec struct {
 	// Required origin URL of the Vault server.
 	// This is a URL with a scheme, a hostname

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
-// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != '')",message="role is requires when credentials.source is Kubernetes"
+// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != ”)",message="role is required when credentials.source is Kubernetes"
 type ProviderConfigSpec struct {
 	// Required origin URL of the Vault server.
 	// This is a URL with a scheme, a hostname

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
-// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != ”)",message="role is required when credentials.source is Kubernetes"
+// +kubebuilder:validation:XValidation:rule="self.credentials.source != 'Kubernetes' || (self.role != null && self.role != '')",message="role is required when credentials.source is Kubernetes"
 type ProviderConfigSpec struct {
 	// Required origin URL of the Vault server.
 	// This is a URL with a scheme, a hostname

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -75,6 +75,11 @@ func (in *ProviderConfigList) DeepCopyObject() runtime.Object {
 func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 	*out = *in
 	out.Headers = in.Headers
+	if in.Role != nil {
+		in, out := &in.Role, &out.Role
+		*out = new(string)
+		**out = **in
+	}
 	in.Credentials.DeepCopyInto(&out.Credentials)
 }
 

--- a/examples/providerconfig/kubernetes.yaml
+++ b/examples/providerconfig/kubernetes.yaml
@@ -1,0 +1,9 @@
+apiVersion: vault.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: vault-provider-config
+spec:
+  address: http://127.0.0.1:8200
+  credentials:
+    source: Kubernetes
+  role: vaultRole

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -71,6 +71,8 @@ const (
 
 	// Service account token path
 	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	credentialsSourceKubernetes xpv1.CredentialsSource = "Kubernetes"
 )
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
@@ -122,8 +124,8 @@ func TerraformSetupBuilder(tfProvider *schema.Provider) terraform.SetupFn {
 		}
 
 		switch pc.Spec.Credentials.Source { //nolint:exhaustive
-		case xpv1.CredentialsSourceInjectedIdentity:
-			if err := injectedIdentityAuth(pc, &ps); err != nil {
+		case credentialsSourceKubernetes:
+			if err := kubernetesAuth(pc, &ps); err != nil {
 				return ps, err
 			}
 		default:
@@ -175,7 +177,7 @@ func commonCredentialsAuth(ctx context.Context, client client.Client, pc *v1beta
 	return nil
 }
 
-func injectedIdentityAuth(pc *v1beta1.ProviderConfig, ps *terraform.Setup) error {
+func kubernetesAuth(pc *v1beta1.ProviderConfig, ps *terraform.Setup) error {
 	jwt, err := os.ReadFile(serviceAccountTokenPath)
 	if err != nil {
 		return errors.Wrap(err, errNoServiceAccountToken)

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -183,7 +183,7 @@ func kubernetesAuth(pc *v1beta1.ProviderConfig, ps *terraform.Setup) error {
 		return errors.Wrap(err, errNoServiceAccountToken)
 	}
 
-	if pc.Spec.Role == nil {
+	if pc.Spec.Role == nil || *pc.Spec.Role == "" {
 		return errors.New(errNoRole)
 	}
 

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -221,7 +221,7 @@ spec:
             x-kubernetes-validations:
             - message: role is required when credentials.source is Kubernetes
               rule: self.credentials.source != 'Kubernetes' || (self.role != null
-                && self.role != ”)
+                && self.role != '')
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
             properties:

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -220,8 +220,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: role is required when credentials.source is Kubernetes
-              rule: self.credentials.source != 'Kubernetes' || (self.role != null
-                && self.role != '')
+              rule: self.credentials.source != 'Kubernetes' || (has(self.role) &&
+                self.role != '')
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
             properties:

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -132,6 +132,7 @@ spec:
                     - InjectedIdentity
                     - Environment
                     - Filesystem
+                    - Kubernetes
                     type: string
                 required:
                 - source
@@ -217,6 +218,10 @@ spec:
             required:
             - address
             type: object
+            x-kubernetes-validations:
+            - message: role is required when credentials.source is Kubernetes
+              rule: self.credentials.source != 'Kubernetes' || (self.role != null
+                && self.role != ”)
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
             properties:

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -221,7 +221,7 @@ spec:
             x-kubernetes-validations:
             - message: role is required when credentials.source is Kubernetes
               rule: self.credentials.source != 'Kubernetes' || (has(self.role) &&
-                self.role != '')
+                self.role != "")
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
             properties:

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -173,6 +173,9 @@ spec:
               namespace:
                 description: Set the namespace to use.
                 type: string
+              role:
+                description: Name of the role against which to login.
+                type: string
               skip_child_token:
                 description: |-
                   Set this to true to disable creation of an


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #5 

This PR implements support for the [Kubernetes authentication method](https://developer.hashicorp.com/vault/docs/auth/kubernetes). This can be configured using the `Kubernetes` credentials source.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have tested this on a cluster with vault deployed and configured for Kubernetes auth. After deploying the provider and configuring it like so:

```yaml
apiVersion: vault.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  address: <Vault address>
  credentials:
    source: Kubernetes
  role: <Vault role>
```

The provider was able to authenticate without issue.

[contribution process]: https://git.io/fj2m9
