### PR TITLE
[release-2.2]: Update go.mod dependencies [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-vault
 
-go 1.23.10
+go 1.23.12
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
Updates go mod dependencies to fix the following CVE:

CVE-2025-47907,CVE-2025-4674