### PR TITLE
fix(apis): fix Items in ClusterProviderConfigList

### DIFF
--- a/apis/namespaced/v1beta1/types.go
+++ b/apis/namespaced/v1beta1/types.go
@@ -209,5 +209,5 @@ type ClusterProviderConfig struct {
 type ClusterProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ProviderConfig `json:"items"`
+	Items           []ClusterProviderConfig `json:"items"`
 }

--- a/apis/namespaced/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/v1beta1/zz_generated.deepcopy.go
@@ -46,7 +46,7 @@ func (in *ClusterProviderConfigList) DeepCopyInto(out *ClusterProviderConfigList
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ProviderConfig, len(*in))
+		*out = make([]ClusterProviderConfig, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fixes the following issue:

```
Warning  CannotConnectToProvider  20s (x3 over 116s)    managed/.... cannot initialize the Terraform plugin SDK async external client: cannot get terraform setup: cannot get referenced ProviderConfig: cache had type *v1beta1.ProviderConfig, but *v1beta1.ClusterProviderConfig was asked for
```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #102

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
