### PR TITLE
feat: Allow configuring the Kubernetes authentication method's mount …

### DIFF
--- a/apis/cluster/v1beta1/types.go
+++ b/apis/cluster/v1beta1/types.go
@@ -95,6 +95,11 @@ type ProviderConfigSpec struct {
 	// +optional
 	Role *string `json:"role,omitempty"`
 
+	// Mount path of the auth method.
+	// +optional
+	// +kubebuilder:default="kubernetes"
+	MountPath *string `json:"mountPath,omitempty"`
+
 	// Credentials required to authenticate to this provider.
 	// There are many options to authenticate. They include
 	// - token - (Optional) Vault token that will be used

--- a/apis/cluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/v1beta1/zz_generated.deepcopy.go
@@ -80,6 +80,11 @@ func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MountPath != nil {
+		in, out := &in.MountPath, &out.MountPath
+		*out = new(string)
+		**out = **in
+	}
 	in.Credentials.DeepCopyInto(&out.Credentials)
 }
 

--- a/apis/namespaced/v1beta1/types.go
+++ b/apis/namespaced/v1beta1/types.go
@@ -96,6 +96,11 @@ type ProviderConfigSpec struct {
 	// +optional
 	Role *string `json:"role,omitempty"`
 
+	// Mount path of the auth method.
+	// +optional
+	// +kubebuilder:default="kubernetes"
+	MountPath *string `json:"mountPath,omitempty"`
+
 	// Credentials required to authenticate to this provider.
 	// There are many options to authenticate. They include
 	// - token - (Optional) Vault token that will be used

--- a/apis/namespaced/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/v1beta1/zz_generated.deepcopy.go
@@ -139,6 +139,11 @@ func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MountPath != nil {
+		in, out := &in.MountPath, &out.MountPath
+		*out = new(string)
+		**out = **in
+	}
 	in.Credentials.DeepCopyInto(&out.Credentials)
 }
 

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -179,10 +179,15 @@ func kubernetesAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.
 		return errors.New(errNoRole)
 	}
 
+	mount := "kubernetes"
+	if pcSpec.MountPath != nil {
+		mount = *pcSpec.MountPath
+	}
+
 	ps.Configuration[keyAuthLoginJWT] = []any{
 		map[string]string{
 			"jwt":   string(jwt),
-			"mount": "kubernetes",
+			"mount": mount,
 			"role":  *pcSpec.Role,
 		},
 	}

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -180,7 +180,7 @@ func kubernetesAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.
 	}
 
 	mount := "kubernetes"
-	if pcSpec.MountPath != nil {
+	if pcSpec.MountPath != nil && *pcSpec.MountPath != "" {
 		mount = *pcSpec.MountPath
 	}
 

--- a/package/crds/vault.m.upbound.io_clusterproviderconfigs.yaml
+++ b/package/crds/vault.m.upbound.io_clusterproviderconfigs.yaml
@@ -171,6 +171,10 @@ spec:
                   Maximum number of retries for Client Controlled
                   Consistency related operations. Defaults to 10 retries.
                 type: integer
+              mountPath:
+                default: kubernetes
+                description: Mount path of the auth method.
+                type: string
               namespace:
                 description: Set the namespace to use.
                 type: string

--- a/package/crds/vault.m.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.m.upbound.io_providerconfigs.yaml
@@ -171,6 +171,10 @@ spec:
                   Maximum number of retries for Client Controlled
                   Consistency related operations. Defaults to 10 retries.
                 type: integer
+              mountPath:
+                default: kubernetes
+                description: Mount path of the auth method.
+                type: string
               namespace:
                 description: Set the namespace to use.
                 type: string

--- a/package/crds/vault.upbound.io_providerconfigs.yaml
+++ b/package/crds/vault.upbound.io_providerconfigs.yaml
@@ -171,6 +171,10 @@ spec:
                   Maximum number of retries for Client Controlled
                   Consistency related operations. Defaults to 10 retries.
                 type: integer
+              mountPath:
+                default: kubernetes
+                description: Mount path of the auth method.
+                type: string
               namespace:
                 description: Set the namespace to use.
                 type: string


### PR DESCRIPTION
…path

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR implements configurable mount path from #93 which seems to be stale. The change is backwards compatible (new field is optional and defaults to previously hardcoded value). I have chosen to change the name of the new field to `mountPath` because Vault refers to it as `path`:
<img width="389" height="299" alt="obraz" src="https://github.com/user-attachments/assets/e7fe5ca2-b1a5-410a-b937-c822404a811d" />

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Executed `make local-deploy` to create local development environment.

Installed HashiCorp Vault in dev mode on the local cluster.

Configured:
* Kubernetes auth method under `custom/` path
* Vault Kubernetes role for use by the provider
* Vault Policy attached to the role

Created `ClusterProviderConfig`:
```yaml
apiVersion: vault.m.upbound.io/v1beta1
kind: ClusterProviderConfig
metadata:
  name: default
spec:
  address: http://vault.upbound-system.svc:8200
  credentials:
    source: Kubernetes
  role: crossplane
  mountPath: custom
```

Created `Policy`:
```yaml
apiVersion: vault.vault.m.upbound.io/v1alpha1
kind: Policy
metadata:
  name: test
  namespace: upbound-system
spec:
  forProvider:
    name: test
    policy: |
      path "secret/test" {
        capabilities = ["update"]
      }
```

`Policy` was successfully created:
```console
❯ kubectl get managed
NAME                                   SYNCED   READY   EXTERNAL-NAME   AGE
policy.vault.vault.m.upbound.io/test   True     True    test            24m
```
<img width="364" height="314" alt="obraz" src="https://github.com/user-attachments/assets/8e72ba39-cf57-48f4-ac68-0de6633cc534" />

[contribution process]: https://git.io/fj2m9
