### PR TITLE
feat: allow configurable mount for Vault Kubernetes auth

### DIFF
--- a/apis/cluster/v1beta1/types.go
+++ b/apis/cluster/v1beta1/types.go
@@ -95,6 +95,9 @@ type ProviderConfigSpec struct {
 	// +optional
 	Role *string `json:"role,omitempty"`
 
+	// Mount point of the auth method to use.
+	Mount *string `json:"mount,omitempty"`
+
 	// Credentials required to authenticate to this provider.
 	// There are many options to authenticate. They include
 	// - token - (Optional) Vault token that will be used

--- a/apis/namespaced/v1beta1/types.go
+++ b/apis/namespaced/v1beta1/types.go
@@ -96,6 +96,10 @@ type ProviderConfigSpec struct {
 	// +optional
 	Role *string `json:"role,omitempty"`
 
+	// Mount point of the auth method to use.
+	Mount *string `json:"mount,omitempty"`
+
+	// Mount point of the auth method to use.
 	// Credentials required to authenticate to this provider.
 	// There are many options to authenticate. They include
 	// - token - (Optional) Vault token that will be used

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -170,24 +170,30 @@ func commonCredentialsAuth(ctx context.Context, client client.Client, pcSpec *na
 }
 
 func kubernetesAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.Setup) error {
-	jwt, err := os.ReadFile(serviceAccountTokenPath)
+    // Default mount to "kubernetes" if not provided
+	mount := "kubernetes"
+    if pcSpec.Mount != nil && *pcSpec.Mount != "" {
+        mount = *pcSpec.Mount
+	}
+
+    jwt, err := os.ReadFile(serviceAccountTokenPath)
 	if err != nil {
-		return errors.Wrap(err, errNoServiceAccountToken)
+        return errors.Wrap(err, errNoServiceAccountToken)
 	}
 
-	if pcSpec.Role == nil || *pcSpec.Role == "" {
-		return errors.New(errNoRole)
-	}
+    if pcSpec.Role == nil || *pcSpec.Role == "" {
+        return errors.New(errNoRole)
+}
 
-	ps.Configuration[keyAuthLoginJWT] = []any{
-		map[string]string{
-			"jwt":   string(jwt),
-			"mount": "kubernetes",
-			"role":  *pcSpec.Role,
-		},
-	}
+    ps.Configuration[keyAuthLoginJWT] = []any{
+        map[string]string{
+            "jwt":   string(jwt),
+            "mount": mount,
+            "role":  *pcSpec.Role,
+        },
+    }
 
-	return nil
+    return nil
 }
 
 func configureNoForkVaultClient(ctx context.Context, ps *terraform.Setup, p schema.Provider) error {
@@ -220,7 +226,7 @@ func legacyToModernProviderConfigSpec(pc *clusterv1beta1.ProviderConfig) (*names
 	var mSpec namespacedv1beta1.ProviderConfigSpec
 	err = json.Unmarshal(data, &mSpec)
 	return &mSpec, err
-}
+	}
 
 func resolveProviderConfig(ctx context.Context, crClient client.Client, mg resource.Managed) (*namespacedv1beta1.ProviderConfigSpec, error) {
 	switch managed := mg.(type) {
@@ -231,13 +237,13 @@ func resolveProviderConfig(ctx context.Context, crClient client.Client, mg resou
 	default:
 		return nil, errors.New("resource is not a managed")
 	}
-}
+	}
 
 func resolveProviderConfigLegacy(ctx context.Context, client client.Client, mg resource.LegacyManaged) (*namespacedv1beta1.ProviderConfigSpec, error) {
 	configRef := mg.GetProviderConfigReference()
 	if configRef == nil {
 		return nil, errors.New(errNoProviderConfig)
-	}
+}
 	pc := &clusterv1beta1.ProviderConfig{}
 	if err := client.Get(ctx, types.NamespacedName{Name: configRef.Name}, pc); err != nil {
 		return nil, errors.Wrap(err, errGetProviderConfig)


### PR DESCRIPTION
- Update `kubernetesAuth` function to use a configurable `mount` value
- Default to "kubernetes" if no mount is provided
- Add `Mount` field to `ProviderConfigSpec` for flexibility

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
