### PR TITLE
Set GO_PROJECT in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 PROJECT_NAME ?= provider-vault
 PROJECT_REPO ?= github.com/upbound/$(PROJECT_NAME)/v4
+GO_PROJECT := github.com/upbound/provider-vault/v4
 
 export TERRAFORM_VERSION := 1.5.5
 


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
This PR proposes to explicitly set the `GO_PROJECT` make variable to `github.com/upbound/provider-vault/v4` after the module version bump to `v4` in https://github.com/upbound/provider-vault/pull/132. The Terraform provider bump there required us to bump the major version due to the breaking changes we had.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
