### PR TITLE
fix(database): make root password create-only for SecretBackendConnection (fixes #38)

### DIFF
--- a/config/database/config.go
+++ b/config/database/config.go
@@ -1,0 +1,70 @@
+// Package database customizes the Upjet configuration for the Vault database
+// secret backend resources.
+package database
+
+import (
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// passwordEngines lists the database engine blocks of
+// vault_database_secret_backend_connection that carry a root "password"
+// attribute. Source of truth: GetConnectionDetailsMapping() in
+// apis/cluster/database/v1alpha1/zz_secretbackendconnection_terraformed.go
+// (every "<engine>[*].password" -> "<engine>[*].passwordSecretRef" entry).
+// Keys are the Terraform (snake_case) attribute names, which is what the
+// flatmap InstanceDiff uses ("<engine>.0.password", MaxItems:1 blocks).
+var passwordEngines = []string{
+	"cassandra",
+	"couchbase",
+	"elasticsearch",
+	"hana",
+	"influxdb",
+	"mongodb",
+	"mssql",
+	"mysql",
+	"mysql_aurora",
+	"mysql_legacy",
+	"mysql_rds",
+	"oracle",
+	"postgresql",
+	"redis",
+	"redis_elasticache",
+	"redshift",
+	"snowflake",
+}
+
+// Configure makes the root "password" of
+// vault_database_secret_backend_connection create-only: it is sent to Vault on
+// the initial Create, but never re-sent on Update/reconcile/cold-start. Vault's
+// database/config/<name> read API never returns the password, so Upjet's diff
+// perpetually sees the password (resolved from passwordSecretRef) as a change
+// and re-applies it, clobbering a rotate-root'd root password (28P01). Dropping
+// the password attribute from the Update diff is the Crossplane-native
+// equivalent of the Terraform `lifecycle.ignore_changes = [<engine>[0].password]`
+// already relied upon. Fixes https://github.com/upbound/provider-vault/issues/38.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("vault_database_secret_backend_connection", func(r *config.Resource) {
+		r.TerraformCustomDiff = passwordCreateOnlyDiff
+	})
+}
+
+// passwordCreateOnlyDiff drops every engine "<engine>.0.password" attribute
+// from an Update diff while leaving the Create diff (empty state ID) intact.
+func passwordCreateOnlyDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	// Nothing to adjust on a nil/empty diff or a delete.
+	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+		return diff, nil
+	}
+	// An empty state ID means this is a Create — let the password through so
+	// the connection is provisioned with it.
+	if state == nil || state.ID == "" {
+		return diff, nil
+	}
+	// Update/reconcile: drop any engine password attribute so the
+	// (now-rotated) password in Vault is not overwritten.
+	for _, e := range passwordEngines {
+		delete(diff.Attributes, e+".0.password")
+	}
+	return diff, nil
+}

--- a/config/database/config_test.go
+++ b/config/database/config_test.go
@@ -1,0 +1,114 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func diffWith(attrs map[string]*terraform.ResourceAttrDiff) *terraform.InstanceDiff {
+	return &terraform.InstanceDiff{Attributes: attrs}
+}
+
+func TestPasswordCreateOnlyDiff(t *testing.T) {
+	pwAttr := func() map[string]*terraform.ResourceAttrDiff {
+		return map[string]*terraform.ResourceAttrDiff{
+			"postgresql.0.password":             {Old: "", New: "s3cr3t"},
+			"mssql.0.password":                  {Old: "", New: "s3cr3t"},
+			"redis_elasticache.0.password":      {Old: "", New: "s3cr3t"},
+			"postgresql.0.max_open_connections": {Old: "0", New: "5"},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		state      *terraform.InstanceState
+		wantPwKept bool // postgresql.0.password still present after the hook
+		wantNonPw  bool // non-password attr always preserved
+	}{
+		{
+			name:       "create keeps password (empty state ID)",
+			state:      &terraform.InstanceState{ID: ""},
+			wantPwKept: true,
+			wantNonPw:  true,
+		},
+		{
+			name:       "create keeps password (nil state)",
+			state:      nil,
+			wantPwKept: true,
+			wantNonPw:  true,
+		},
+		{
+			name:       "update drops password (non-empty state ID)",
+			state:      &terraform.InstanceState{ID: "database/config/db-foo"},
+			wantPwKept: false,
+			wantNonPw:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := diffWith(pwAttr())
+			out, err := passwordCreateOnlyDiff(d, tc.state, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_, pwKept := out.Attributes["postgresql.0.password"]
+			if pwKept != tc.wantPwKept {
+				t.Errorf("postgresql.0.password present=%v, want %v", pwKept, tc.wantPwKept)
+			}
+			// On update, ALL engine passwords must be gone.
+			if !tc.wantPwKept {
+				for _, k := range []string{"mssql.0.password", "redis_elasticache.0.password"} {
+					if _, ok := out.Attributes[k]; ok {
+						t.Errorf("%s should have been dropped on update", k)
+					}
+				}
+			}
+			if _, ok := out.Attributes["postgresql.0.max_open_connections"]; ok != tc.wantNonPw {
+				t.Errorf("non-password attr present=%v, want %v", ok, tc.wantNonPw)
+			}
+		})
+	}
+}
+
+func TestPasswordCreateOnlyDiff_NilAndDestroy(t *testing.T) {
+	// nil diff → returned as-is, no panic
+	if out, err := passwordCreateOnlyDiff(nil, &terraform.InstanceState{ID: "x"}, nil); err != nil || out != nil {
+		t.Errorf("nil diff: got (%v, %v), want (nil, nil)", out, err)
+	}
+	// destroy diff → untouched
+	d := &terraform.InstanceDiff{Destroy: true, Attributes: map[string]*terraform.ResourceAttrDiff{
+		"postgresql.0.password": {Old: "x", New: ""},
+	}}
+	out, err := passwordCreateOnlyDiff(d, &terraform.InstanceState{ID: "x"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := out.Attributes["postgresql.0.password"]; !ok {
+		t.Error("destroy diff must not be modified")
+	}
+}
+
+func TestPasswordEnginesComplete(t *testing.T) {
+	// Guard against drift: every engine known to carry a password must be listed.
+	want := map[string]bool{
+		"cassandra": true, "couchbase": true, "elasticsearch": true, "hana": true,
+		"influxdb": true, "mongodb": true, "mssql": true, "mysql": true,
+		"mysql_aurora": true, "mysql_legacy": true, "mysql_rds": true, "oracle": true,
+		"postgresql": true, "redis": true, "redis_elasticache": true, "redshift": true,
+		"snowflake": true,
+	}
+	got := map[string]bool{}
+	for _, e := range passwordEngines {
+		got[e] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("passwordEngines has %d entries, want %d", len(got), len(want))
+	}
+	for e := range want {
+		if !got[e] {
+			t.Errorf("missing engine %q in passwordEngines", e)
+		}
+	}
+}

--- a/config/provider.go
+++ b/config/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/upbound/provider-vault/v4/config/database"
 	"github.com/upbound/provider-vault/v4/config/vault"
 )
 
@@ -88,6 +89,7 @@ func GetProvider(_ context.Context, sdkProvider *tfschema.Provider, fwProvider p
 	for _, configure := range []func(provider *ujconfig.Provider){
 		// add custom config functions
 		vault.Configure,
+		database.Configure,
 	} {
 		configure(pc)
 	}
@@ -130,6 +132,7 @@ func GetProviderNamespaced(_ context.Context, sdkProvider *tfschema.Provider, fw
 	for _, configure := range []func(provider *ujconfig.Provider){
 		// add custom config functions
 		vault.Configure,
+		database.Configure,
 	} {
 		configure(pc)
 	}


### PR DESCRIPTION
### Problem (fixes #38)

`vault_database_secret_backend_connection` re-sends the root `password` on **every** reconcile, clobbering a `rotate-root`'d password (28P01 / broken dynamic creds).

Root cause: Vault's `database/config/<name>` read API never returns the password, so the refreshed Terraform state has no password. Upjet then diffs the desired config (with the password resolved from `passwordSecretRef`) against state (no password) → a perpetual non-empty diff on `<engine>.0.password` → `databaseSecretBackendConnectionUpdate`'s `d.HasChange(passwordKey)` is true every reconcile → the password is PUT back to `database/config`, overwriting whatever `rotate-root` last set.

This makes the resource fundamentally incompatible with `rotate-root`, which is the documented way to take ownership of the root credential after creation.

### Fix

A `TerraformCustomDiff` that drops every engine `<engine>.0.password` attribute from the **Update** diff (keyed on a non-empty Terraform state ID) while leaving the **Create** diff intact. The password is sent once at creation and never re-sent on reconcile, so a rotated password survives.

This is the Crossplane-native equivalent of the well-known Terraform workaround `lifecycle.ignore_changes = [postgresql[0].password]`.

- Pure Upjet config (`config/database/config.go` + wiring in `config/provider.go`) — no schema/CRD change, no `make generate` diff.
- Create path unchanged (password still required + sent for new connections).
- Engine list sourced from `GetConnectionDetailsMapping()` (all 17 engines with a root password); a unit test guards against drift.

### Test

`config/database/config_test.go`: Create keeps the password; Update drops it for all engines; nil/Destroy diffs untouched; engine-list completeness.

Validated in production (Crossplane v2) across two clusters: with this change the connections reconcile under full `managementPolicies` without ever re-writing `database/config`, and a `rotate-root`'d password survives provider cold-starts.
