### PR TITLE
ci: setup go after PR checkout in uptest jobs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,11 +94,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
       - name: Checkout PR
         id: checkout-pr
         env:
@@ -108,6 +103,11 @@ jobs:
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check


### PR DESCRIPTION
### Description of your changes

In E2E uptest runs in GH actions, setup go after the PR checkout. 
so that the go version specified at the PR is used if the PR changes go version in go.mod, the 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
