### PR TITLE
fix: wire TF plugin framework provider to client setup

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -4,7 +4,13 @@ Copyright 2022 Upbound Inc.
 
 package config
 
-import "github.com/crossplane/upjet/v2/pkg/config"
+import (
+	"context"
+	"strings"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
 
 // ExternalNameConfigs contains all external name configurations for this
 // provider.
@@ -138,7 +144,42 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 }
 
 var TerraformPluginFrameworkExternalNameConfigs = map[string]config.ExternalName{
-	"vault_password_policy": config.IdentifierFromProvider,
+	"vault_password_policy": vaultPasswordPolicy(),
+}
+
+// vaultPasswordPolicy returns the external name configuration for
+// vault_password_policy TF resource.
+// Ideally, this resource should have been NameAsIdentifier,
+// however, keeping it unnormalized to preserve backward compatibility.
+func vaultPasswordPolicy() config.ExternalName { //nolint:gocyclo
+	e := config.IdentifierFromProvider
+	e.SetIdentifierArgumentFn = func(base map[string]any, externalName string) {
+		if externalName != "" {
+			base["name"] = externalName
+		}
+
+	}
+	e.GetIDFn = func(_ context.Context, externalName string, parameters map[string]any, _ map[string]any) (string, error) {
+		if externalName == "" {
+			return parameters["name"].(string), nil
+		}
+		return externalName, nil
+	}
+	// NOTE: Upstream vault client impl surfaces 404s as nil struct + nil error
+	// ref: https://github.com/hashicorp/vault/blob/99d122d00c97ba40c6c8965f02edcb0064030c78/api/logical.go#L154
+	// Upstream TF provider Read impl always surfaces this as an error-severity diagnostics
+	// ref: https://github.com/hashicorp/terraform-provider-vault/blob/0f882c6450f1405418e6349e35354f2209a3af5c/internal/vault/sys/password_policy.go#L175-L178
+	e.IsNotFoundDiagnosticFn = func(diags []*tfprotov6.Diagnostic) bool {
+		for _, diag := range diags {
+			if diag.Severity == tfprotov6.DiagnosticSeverityError &&
+				diag.Summary == "Unable to Read Resource from Vault" &&
+				strings.HasSuffix(diag.Detail, "Vault response was nil") {
+				return true
+			}
+		}
+		return false
+	}
+	return e
 }
 
 // ExternalNameConfigurations applies all external name configs listed in the

--- a/examples/cluster/password/passwordpolicy.yaml
+++ b/examples/cluster/password/passwordpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: password.vault.upbound.io/v1alpha1
+kind: Policy
+metadata:
+  name: example-password-policy
+spec:
+  forProvider:
+    name: example-password-policy
+    policy: |
+      length = 20
+      rule "charset" {
+        charset = "abcdefghijklmnopqrstuvwxyz"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "0123456789"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "!@#$%^&*()-_=+[]{}|;:,.<>?"
+        min-chars = 1
+      }
+  providerConfigRef:
+    name: vault-provider-config

--- a/examples/namespaced/password/passwordpolicy.yaml
+++ b/examples/namespaced/password/passwordpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: password.vault.m.upbound.io/v1alpha1
+kind: Policy
+metadata:
+  name: example-password-policy
+  namespace: upbound-system
+spec:
+  forProvider:
+    name: example-password-policy
+    policy: |
+      length = 20
+      rule "charset" {
+        charset = "abcdefghijklmnopqrstuvwxyz"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "0123456789"
+        min-chars = 1
+      }
+      rule "charset" {
+        charset = "!@#$%^&*()-_=+[]{}|;:,.<>?"
+        min-chars = 1
+      }
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: vault-provider-config

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/hashicorp/terraform-provider-vault v1.9.1-0.20250709180749-dc098d37d2bc
 	github.com/pkg/errors v0.9.1
@@ -160,7 +161,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.0 // indirect
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.23.1 // indirect
 	github.com/hashicorp/terraform-plugin-testing v1.15.0 // indirect

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -18,6 +18,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tfsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/xpprovider"
 
 	clusterv1beta1 "github.com/upbound/provider-vault/v4/apis/cluster/v1beta1"
 	namespacedv1beta1 "github.com/upbound/provider-vault/v4/apis/namespaced/v1beta1"
@@ -209,6 +210,7 @@ func configureNoForkVaultClient(ctx context.Context, ps *terraform.Setup, p sche
 		return errors.Errorf("failed to configure the provider: %v", diag)
 	}
 	ps.Meta = p.Meta()
+	ps.FrameworkProvider = xpprovider.FrameworkProvider(&p)
 	return nil
 }
 


### PR DESCRIPTION
### Description of your changes

#### Fix the missing wiring for the `FrameworkProvider` during no-fork client initialization.
This affects `Policy.password.vault.{m}.upbound.io` MRs, which is the only Plugin Framework resource.

#### Fix the external name config for Policy.password MR

Upstream vault client impl surfaces 404s as nil struct + nil error ([ref](https://github.com/hashicorp/vault/blob/99d122d00c97ba40c6c8965f02edcb0064030c78/api/logical.go#L154))
and upstream TF provider Read impl always surfaces this as an error-severity diagnostics ([ref](https://github.com/hashicorp/terraform-provider-vault/blob/0f882c6450f1405418e6349e35354f2209a3af5c/internal/vault/sys/password_policy.go#L175-L178)) , therefore it was never possible to get proper "resource not found" after Observes. Configured suppresion for the particular diagnostics.

Secondly, the resource had `IdentifierFromProvider` external-name configuration. This was working fine for SDKv2, due to empty ID implicitly interpreted as "not found" in TF SDKv2. After the upstream resource switched to Plugin Framework, this did not work anymore. This resource ideally should be `NameAsIdentifier` but to keep the API backwards compatible, the external name config is kept unnormalized (external-name annotation and the `spec.forProvider.name` is redundantly same).

Fixes #137 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Added new example manifests, uptest:

[Uptest-examples/cluster/password/passwordpolicy.yaml](https://github.com/upbound/provider-vault/actions/runs/30015805263) — Passed
[Uptest-examples/namespaced/password/passwordpolicy.yaml](https://github.com/upbound/provider-vault/actions/runs/30020764982) — Passed

[contribution process]: https://git.io/fj2m9
