### PR TITLE
[Backport release-4.0] Do not generate webhook setup functions

### DIFF
--- a/config/provider.go
+++ b/config/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/upbound/provider-vault/v4/config/templates"
 	"github.com/upbound/provider-vault/v4/config/vault"
 )
 
@@ -83,6 +84,8 @@ func GetProvider(_ context.Context, sdkProvider *tfschema.Provider, fwProvider p
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithTerraformProvider(sdkProvider),
 		ujconfig.WithTerraformPluginFrameworkProvider(fwProvider),
+		ujconfig.WithControllerTemplate(templates.ControllerTemplate),
+		ujconfig.WithSetupAggregatorTemplate(templates.SetupAggregatorTemplate),
 	)
 
 	for _, configure := range []func(provider *ujconfig.Provider){
@@ -125,6 +128,8 @@ func GetProviderNamespaced(_ context.Context, sdkProvider *tfschema.Provider, fw
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithTerraformProvider(sdkProvider),
 		ujconfig.WithTerraformPluginFrameworkProvider(fwProvider),
+		ujconfig.WithControllerTemplate(templates.ControllerTemplate),
+		ujconfig.WithSetupAggregatorTemplate(templates.SetupAggregatorTemplate),
 	)
 
 	for _, configure := range []func(provider *ujconfig.Provider){

--- a/config/templates/controller.go.tmpl
+++ b/config/templates/controller.go.tmpl
@@ -1,0 +1,146 @@
+{{ .Header }}
+
+{{ .GenStatement }}
+
+package {{ .Package }}
+
+import (
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	xpfeature "github.com/crossplane/crossplane-runtime/v2/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
+	"github.com/crossplane/upjet/v2/pkg/controller/handler"
+	tjcontroller "github.com/crossplane/upjet/v2/pkg/controller"
+	"github.com/crossplane/upjet/v2/pkg/metrics"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/pkg/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	{{ .Imports }}
+)
+
+// SetupGated adds a controller that reconciles {{ .CRD.Kind }} managed resources.
+func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
+	o.Options.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", {{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind.String())
+		}
+	}, {{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind)
+	return nil
+}
+
+// Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
+func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
+	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	{{- if .Initializers }}
+	for _, i := range o.Provider.Resources["{{ .ResourceType }}"].InitializerFns {
+	    initializers = append(initializers,i(mgr.GetClient()))
+	}
+	{{- end}}
+	{{- if not .DisableNameInitializer }}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
+	{{- end}}
+	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", {{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind)))
+	{{- if .UseAsync }}
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler){{ if or .UseTerraformPluginSDKClient .UseTerraformPluginFrameworkClient }}, tjcontroller.WithStatusUpdates(false){{ end }})
+	{{- end}}
+	opts := []managed.ReconcilerOption{
+		managed.WithExternalConnecter(
+			{{- if .UseTerraformPluginSDKClient -}}
+              {{- if .UseAsync }}
+              tjcontroller.NewTerraformPluginSDKAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"],
+                tjcontroller.WithTerraformPluginSDKAsyncLogger(o.Logger),
+                tjcontroller.WithTerraformPluginSDKAsyncConnectorEventHandler(eventHandler),
+                tjcontroller.WithTerraformPluginSDKAsyncCallbackProvider(ac),
+                tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+                {{if .FeaturesPackageAlias -}}
+                  tjcontroller.WithTerraformPluginSDKAsyncManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableBetaManagementPolicies))
+                {{- end -}}
+                )
+              {{- else -}}
+			  tjcontroller.NewTerraformPluginSDKConnector(mgr.GetClient(), o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], o.OperationTrackerStore,
+				tjcontroller.WithTerraformPluginSDKLogger(o.Logger),
+				tjcontroller.WithTerraformPluginSDKMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+				{{if .FeaturesPackageAlias -}}
+				  tjcontroller.WithTerraformPluginSDKManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableBetaManagementPolicies))
+				{{- end -}}
+				)
+			  {{- end -}}
+			{{- else if .UseTerraformPluginFrameworkClient -}}
+			  {{- if .UseAsync }}
+          tjcontroller.NewTerraformPluginFrameworkAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"],
+          tjcontroller.WithTerraformPluginFrameworkAsyncLogger(o.Logger),
+          tjcontroller.WithTerraformPluginFrameworkAsyncConnectorEventHandler(eventHandler),
+          tjcontroller.WithTerraformPluginFrameworkAsyncCallbackProvider(ac),
+          tjcontroller.WithTerraformPluginFrameworkAsyncMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+          {{if .FeaturesPackageAlias -}}
+            tjcontroller.WithTerraformPluginFrameworkAsyncManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableBetaManagementPolicies))
+          {{- end -}}
+          )
+			  {{- else }}
+			  tjcontroller.NewTerraformPluginFrameworkConnector(mgr.GetClient(), o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], o.OperationTrackerStore,
+				tjcontroller.WithTerraformPluginFrameworkLogger(o.Logger),
+				tjcontroller.WithTerraformPluginFrameworkMetricRecorder(metrics.NewMetricRecorder({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind, mgr, o.PollInterval)),
+				{{if .FeaturesPackageAlias -}}
+				  tjcontroller.WithTerraformPluginFrameworkManagementPolicies(o.Features.Enabled({{ .FeaturesPackageAlias }}EnableBetaManagementPolicies))
+				{{- end -}}
+			  )
+			  {{- end }}
+			{{- else -}}
+			  tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler),
+				{{- if .UseAsync }}
+				tjcontroller.WithCallbackProvider(ac),
+				{{- end }}
+			  )
+			{{- end -}}
+		),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		{{- if or .UseTerraformPluginSDKClient .UseTerraformPluginFrameworkClient }}
+		managed.WithFinalizer(tjcontroller.NewOperationTrackerFinalizer(o.OperationTrackerStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
+    {{- else }}
+    managed.WithFinalizer(terraform.NewWorkspaceFinalizer(o.WorkspaceStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
+    {{- end }}
+		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
+		managed.WithPollInterval(o.PollInterval),
+	}
+	if o.PollJitter != 0 {
+	    opts = append(opts, managed.WithPollJitterHook(o.PollJitter))
+	}
+	{{- if .FeaturesPackageAlias }}
+	if o.Features.Enabled({{ .FeaturesPackageAlias }}EnableBetaManagementPolicies) {
+		opts = append(opts, managed.WithManagementPolicies())
+	}
+	{{- end}}
+	if o.MetricOptions != nil {
+		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
+	}
+
+	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
+		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &{{ .TypePackageAlias }}{{ .CRD.Kind }}List{}, o.MetricOptions.PollStateMetricInterval,
+		)
+		if err := mgr.Add(stateMetricsRecorder); err != nil {
+			return errors.Wrap(err, "cannot register MR state metrics recorder for kind {{ .TypePackageAlias }}{{ .CRD.Kind }}List")
+		}
+	}
+
+	if o.Features.Enabled(xpfeature.EnableAlphaChangeLogs) {
+		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
+	}
+
+	r := managed.NewReconciler(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), opts...)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(xpresource.DesiredStateChanged()).
+		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, eventHandler).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}

--- a/config/templates/embed.go
+++ b/config/templates/embed.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package templates
+
+import _ "embed"
+
+// ControllerTemplate is the template for the MR controller setup files.
+//
+//go:embed controller.go.tmpl
+var ControllerTemplate string
+
+// SetupAggregatorTemplate is the template used for generating
+// the controller setup aggregators.
+//
+//go:embed setup.go.tmpl
+var SetupAggregatorTemplate string

--- a/config/templates/setup.go.tmpl
+++ b/config/templates/setup.go.tmpl
@@ -1,0 +1,41 @@
+{{ .Header }}
+
+package controller
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplane/upjet/v2/pkg/controller"
+
+	{{ .Imports }}
+)
+
+// Setup{{ .Group }} creates all controllers with the supplied logger and adds them to
+// the supplied manager.
+func Setup{{ .Group }}(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		{{- range $alias := .Aliases }}
+		{{ $alias }}Setup,
+		{{- end }}
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated{{ .Group }} creates all controllers with the supplied logger and adds them to
+// the supplied manager gated.
+func SetupGated{{ .Group }}(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		{{- range $alias := .Aliases }}
+		{{ $alias }}SetupGated,
+		{{- end }}
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
-	github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4
+	github.com/crossplane/upjet/v2 v2.3.1-0.20260703134037-c73cc3a2d247
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.2.0 h1:jLoQm9D5buk9lBqwRtQ40ueaFo
 github.com/crossplane/crossplane-runtime/v2 v2.2.0/go.mod h1:8I+x4w5bG4x8aO8ifF/QC8GZoNCN6v21NHzgoYPNYAQ=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec h1:+51Et4UW8XrvGne8RAqn9qEIfhoqPXYqIp/kQvpMaAo=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4 h1:ilL+vJYh88KscCt/VKIT+CiP/R82+KIvbkiuo5X0ceI=
-github.com/crossplane/upjet/v2 v2.2.1-0.20260610110527-59c45527ebe4/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
+github.com/crossplane/upjet/v2 v2.3.1-0.20260703134037-c73cc3a2d247 h1:Llb4TFiXYa6gUbM0nAzKyNAJKemLZPCnX21KNOtTjNQ=
+github.com/crossplane/upjet/v2 v2.3.1-0.20260703134037-c73cc3a2d247/go.mod h1:5eAaUqFKfA0LAlkywhQVj3jBAvepqb4pJAb9EsdWsuM=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=

--- a/internal/controller/cluster/ad/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/ad/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ad/secretrole/zz_controller.go
+++ b/internal/controller/cluster/ad/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/alicloud/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/alicloud/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/approle/authbackendlogin/zz_controller.go
+++ b/internal/controller/cluster/approle/authbackendlogin/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendLogin
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendLogin{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendLogin")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendLoginList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/approle/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/approle/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/approle/authbackendrolesecretid/zz_controller.go
+++ b/internal/controller/cluster/approle/authbackendrolesecretid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoleSecretID
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoleSecretID{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoleSecretID")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleSecretIDList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/audit/requestheader/zz_controller.go
+++ b/internal/controller/cluster/audit/requestheader/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.RequestHeader
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.RequestHeader{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.RequestHeader")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RequestHeaderList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/auth/backend/zz_controller.go
+++ b/internal/controller/cluster/auth/backend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Backend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Backend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Backend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.BackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendcert/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendclient/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendclient/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendClient
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendClient{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendClient")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendClientList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendconfigidentity/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendconfigidentity/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfigIdentity
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfigIdentity{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfigIdentity")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigIdentityList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendidentitywhitelist/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendidentitywhitelist/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendIdentityWhitelist
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendIdentityWhitelist{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendIdentityWhitelist")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendIdentityWhitelistList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendlogin/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendlogin/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendLogin
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendLogin{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendLogin")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendLoginList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendroletag/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendroletag/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoleTag
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoleTag{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoleTag")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleTagList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendroletagblacklist/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendroletagblacklist/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoletagBlacklist
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoletagBlacklist{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoletagBlacklist")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoletagBlacklistList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/authbackendstsrole/zz_controller.go
+++ b/internal/controller/cluster/aws/authbackendstsrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendStsRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendStsRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendStsRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendStsRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/aws/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/aws/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/aws/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/azure/authbackendconfig/zz_controller.go
+++ b/internal/controller/cluster/azure/authbackendconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/azure/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/azure/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/azure/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/azure/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/azure/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/azure/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/cert/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/cert/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/consul/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/consul/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/consul/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/consul/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/database/secretbackendconnection/zz_controller.go
+++ b/internal/controller/cluster/database/secretbackendconnection/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConnection
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConnection{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConnection")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConnectionList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/database/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/database/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/database/secretbackendstaticrole/zz_controller.go
+++ b/internal/controller/cluster/database/secretbackendstaticrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendStaticRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendStaticRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendStaticRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendStaticRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/database/secretsmount/zz_controller.go
+++ b/internal/controller/cluster/database/secretsmount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretsMount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretsMount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretsMount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretsMountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/egp/policy/zz_controller.go
+++ b/internal/controller/cluster/egp/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/authbackend/zz_controller.go
+++ b/internal/controller/cluster/gcp/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/gcp/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/gcp/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/secretimpersonatedaccount/zz_controller.go
+++ b/internal/controller/cluster/gcp/secretimpersonatedaccount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretImpersonatedAccount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretImpersonatedAccount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretImpersonatedAccount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretImpersonatedAccountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/secretroleset/zz_controller.go
+++ b/internal/controller/cluster/gcp/secretroleset/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRoleset
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRoleset{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRoleset")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRolesetList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/gcp/secretstaticaccount/zz_controller.go
+++ b/internal/controller/cluster/gcp/secretstaticaccount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretStaticAccount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretStaticAccount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretStaticAccount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretStaticAccountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/generic/endpoint/zz_controller.go
+++ b/internal/controller/cluster/generic/endpoint/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Endpoint
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Endpoint{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Endpoint")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EndpointList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/generic/secret/zz_controller.go
+++ b/internal/controller/cluster/generic/secret/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Secret
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Secret")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/github/authbackend/zz_controller.go
+++ b/internal/controller/cluster/github/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/github/team/zz_controller.go
+++ b/internal/controller/cluster/github/team/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Team
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Team{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Team")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TeamList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/github/user/zz_controller.go
+++ b/internal/controller/cluster/github/user/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.User
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.User{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.User")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.UserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/entity/zz_controller.go
+++ b/internal/controller/cluster/identity/entity/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Entity
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Entity{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Entity")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/entityalias/zz_controller.go
+++ b/internal/controller/cluster/identity/entityalias/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.EntityAlias
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.EntityAlias{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.EntityAlias")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityAliasList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/entitypolicies/zz_controller.go
+++ b/internal/controller/cluster/identity/entitypolicies/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.EntityPolicies
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.EntityPolicies{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.EntityPolicies")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityPoliciesList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/group/zz_controller.go
+++ b/internal/controller/cluster/identity/group/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Group
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Group{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Group")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/groupalias/zz_controller.go
+++ b/internal/controller/cluster/identity/groupalias/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupAlias
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupAlias{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupAlias")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupAliasList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/groupmemberentityids/zz_controller.go
+++ b/internal/controller/cluster/identity/groupmemberentityids/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupMemberEntityIds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupMemberEntityIds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupMemberEntityIds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupMemberEntityIdsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/groupmembergroupids/zz_controller.go
+++ b/internal/controller/cluster/identity/groupmembergroupids/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupMemberGroupIds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupMemberGroupIds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupMemberGroupIds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupMemberGroupIdsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/grouppolicies/zz_controller.go
+++ b/internal/controller/cluster/identity/grouppolicies/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupPolicies
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupPolicies{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupPolicies")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupPoliciesList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/mfaduo/zz_controller.go
+++ b/internal/controller/cluster/identity/mfaduo/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaDuo
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaDuo{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaDuo")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaDuoList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/mfaloginenforcement/zz_controller.go
+++ b/internal/controller/cluster/identity/mfaloginenforcement/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaLoginEnforcement
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaLoginEnforcement{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaLoginEnforcement")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaLoginEnforcementList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/mfaokta/zz_controller.go
+++ b/internal/controller/cluster/identity/mfaokta/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaOkta
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaOkta{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaOkta")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaOktaList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/mfapingid/zz_controller.go
+++ b/internal/controller/cluster/identity/mfapingid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaPingid
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaPingid{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaPingid")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaPingidList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/mfatotp/zz_controller.go
+++ b/internal/controller/cluster/identity/mfatotp/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaTotp
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaTotp{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaTotp")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaTotpList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidc/zz_controller.go
+++ b/internal/controller/cluster/identity/oidc/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Oidc
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Oidc{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Oidc")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidcassignment/zz_controller.go
+++ b/internal/controller/cluster/identity/oidcassignment/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcAssignment
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcAssignment")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcAssignmentList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidcclient/zz_controller.go
+++ b/internal/controller/cluster/identity/oidcclient/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcClient
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcClient{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcClient")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcClientList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidckey/zz_controller.go
+++ b/internal/controller/cluster/identity/oidckey/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcKey
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcKey{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcKey")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcKeyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidckeyallowedclientid/zz_controller.go
+++ b/internal/controller/cluster/identity/oidckeyallowedclientid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcKeyAllowedClientID
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcKeyAllowedClientID{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcKeyAllowedClientID")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcKeyAllowedClientIDList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidcprovider/zz_controller.go
+++ b/internal/controller/cluster/identity/oidcprovider/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcProvider
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcProvider{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcProvider")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcProviderList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidcrole/zz_controller.go
+++ b/internal/controller/cluster/identity/oidcrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/identity/oidcscope/zz_controller.go
+++ b/internal/controller/cluster/identity/oidcscope/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcScope
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcScope{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcScope")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcScopeList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/jwt/authbackend/zz_controller.go
+++ b/internal/controller/cluster/jwt/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/jwt/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/jwt/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kmip/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/kmip/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kmip/secretrole/zz_controller.go
+++ b/internal/controller/cluster/kmip/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kmip/secretscope/zz_controller.go
+++ b/internal/controller/cluster/kmip/secretscope/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretScope
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretScope{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretScope")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretScopeList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kubernetes/authbackendconfig/zz_controller.go
+++ b/internal/controller/cluster/kubernetes/authbackendconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kubernetes/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/kubernetes/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kubernetes/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/kubernetes/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kubernetes/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/kubernetes/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kv/secret/zz_controller.go
+++ b/internal/controller/cluster/kv/secret/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Secret
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Secret")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kv/secretbackendv2/zz_controller.go
+++ b/internal/controller/cluster/kv/secretbackendv2/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendV2
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendV2{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendV2")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendV2List{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/kv/secretv2/zz_controller.go
+++ b/internal/controller/cluster/kv/secretv2/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretV2
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretV2{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretV2")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretV2List{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ldap/authbackend/zz_controller.go
+++ b/internal/controller/cluster/ldap/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ldap/authbackendgroup/zz_controller.go
+++ b/internal/controller/cluster/ldap/authbackendgroup/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendGroup
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendGroup{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendGroup")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendGroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ldap/authbackenduser/zz_controller.go
+++ b/internal/controller/cluster/ldap/authbackenduser/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendUser
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendUser{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendUser")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendUserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/managed/keys/zz_controller.go
+++ b/internal/controller/cluster/managed/keys/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Keys
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Keys{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Keys")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.KeysList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mfa/duo/zz_controller.go
+++ b/internal/controller/cluster/mfa/duo/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Duo
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Duo{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Duo")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.DuoList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mfa/okta/zz_controller.go
+++ b/internal/controller/cluster/mfa/okta/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Okta
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Okta{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Okta")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OktaList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mfa/pingid/zz_controller.go
+++ b/internal/controller/cluster/mfa/pingid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Pingid
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Pingid{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Pingid")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PingidList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mfa/totp/zz_controller.go
+++ b/internal/controller/cluster/mfa/totp/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Totp
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Totp{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Totp")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TotpList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mongodbatlas/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/mongodbatlas/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/mongodbatlas/secretrole/zz_controller.go
+++ b/internal/controller/cluster/mongodbatlas/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/nomad/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/nomad/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/nomad/secretrole/zz_controller.go
+++ b/internal/controller/cluster/nomad/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/okta/authbackend/zz_controller.go
+++ b/internal/controller/cluster/okta/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/okta/authbackendgroup/zz_controller.go
+++ b/internal/controller/cluster/okta/authbackendgroup/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendGroup
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendGroup{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendGroup")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendGroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/okta/authbackenduser/zz_controller.go
+++ b/internal/controller/cluster/okta/authbackenduser/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendUser
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendUser{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendUser")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendUserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/password/policy/zz_controller.go
+++ b/internal/controller/cluster/password/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendcert/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendconfigca/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendconfigca/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConfigCA
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConfigCA{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConfigCA")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConfigCAList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendconfigurls/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendconfigurls/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConfigUrls
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConfigUrls{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConfigUrls")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConfigUrlsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendcrlconfig/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendcrlconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCrlConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCrlConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCrlConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCrlConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendintermediatecertrequest/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendintermediatecertrequest/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendIntermediateCertRequest
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendIntermediateCertRequest{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendIntermediateCertRequest")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendIntermediateCertRequestList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendintermediatesetsigned/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendintermediatesetsigned/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendIntermediateSetSigned
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendIntermediateSetSigned{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendIntermediateSetSigned")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendIntermediateSetSignedList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendrootcert/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendrootcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRootCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRootCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRootCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRootCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendrootsignintermediate/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendrootsignintermediate/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRootSignIntermediate
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRootSignIntermediate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRootSignIntermediate")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRootSignIntermediateList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/pki/secretbackendsign/zz_controller.go
+++ b/internal/controller/cluster/pki/secretbackendsign/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendSign
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendSign{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendSign")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendSignList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/quota/leasecount/zz_controller.go
+++ b/internal/controller/cluster/quota/leasecount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.LeaseCount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.LeaseCount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.LeaseCount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.LeaseCountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/quota/ratelimit/zz_controller.go
+++ b/internal/controller/cluster/quota/ratelimit/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.RateLimit
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.RateLimit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.RateLimit")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RateLimitList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/rabbitmq/secretbackend/zz_controller.go
+++ b/internal/controller/cluster/rabbitmq/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/rabbitmq/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/rabbitmq/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/raft/autopilot/zz_controller.go
+++ b/internal/controller/cluster/raft/autopilot/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Autopilot
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Autopilot{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Autopilot")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AutopilotList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/raft/snapshotagentconfig/zz_controller.go
+++ b/internal/controller/cluster/raft/snapshotagentconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SnapshotAgentConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SnapshotAgentConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SnapshotAgentConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SnapshotAgentConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/rgp/policy/zz_controller.go
+++ b/internal/controller/cluster/rgp/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ssh/secretbackendca/zz_controller.go
+++ b/internal/controller/cluster/ssh/secretbackendca/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCA
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCA{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCA")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCAList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/ssh/secretbackendrole/zz_controller.go
+++ b/internal/controller/cluster/ssh/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/terraform/cloudsecretbackend/zz_controller.go
+++ b/internal/controller/cluster/terraform/cloudsecretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/terraform/cloudsecretcreds/zz_controller.go
+++ b/internal/controller/cluster/terraform/cloudsecretcreds/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretCreds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretCreds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretCreds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretCredsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/terraform/cloudsecretrole/zz_controller.go
+++ b/internal/controller/cluster/terraform/cloudsecretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/token/authbackendrole/zz_controller.go
+++ b/internal/controller/cluster/token/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/transform/alphabet/zz_controller.go
+++ b/internal/controller/cluster/transform/alphabet/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Alphabet
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Alphabet{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Alphabet")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AlphabetList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/transform/role/zz_controller.go
+++ b/internal/controller/cluster/transform/role/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Role
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Role{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Role")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/transform/template/zz_controller.go
+++ b/internal/controller/cluster/transform/template/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Template
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Template{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Template")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TemplateList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/transform/transformation/zz_controller.go
+++ b/internal/controller/cluster/transform/transformation/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Transformation
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Transformation{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Transformation")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TransformationList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/transit/secretbackendkey/zz_controller.go
+++ b/internal/controller/cluster/transit/secretbackendkey/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendKey
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendKey{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendKey")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendKeyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/vault/audit/zz_controller.go
+++ b/internal/controller/cluster/vault/audit/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Audit
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Audit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Audit")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuditList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/vault/mount/zz_controller.go
+++ b/internal/controller/cluster/vault/mount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Mount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Mount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Mount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/vault/policy/zz_controller.go
+++ b/internal/controller/cluster/vault/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/vault/token/zz_controller.go
+++ b/internal/controller/cluster/vault/token/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Token
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Token{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Token")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TokenList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/cluster/vault/vaultnamespace/zz_controller.go
+++ b/internal/controller/cluster/vault/vaultnamespace/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.VaultNamespace
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.VaultNamespace{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.VaultNamespace")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.VaultNamespaceList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ad/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/ad/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ad/secretrole/zz_controller.go
+++ b/internal/controller/namespaced/ad/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/alicloud/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/alicloud/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/approle/authbackendlogin/zz_controller.go
+++ b/internal/controller/namespaced/approle/authbackendlogin/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendLogin
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendLogin{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendLogin")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendLoginList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/approle/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/approle/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/approle/authbackendrolesecretid/zz_controller.go
+++ b/internal/controller/namespaced/approle/authbackendrolesecretid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoleSecretID
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoleSecretID{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoleSecretID")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleSecretIDList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/audit/requestheader/zz_controller.go
+++ b/internal/controller/namespaced/audit/requestheader/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.RequestHeader
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.RequestHeader{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.RequestHeader")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RequestHeaderList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/auth/backend/zz_controller.go
+++ b/internal/controller/namespaced/auth/backend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Backend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Backend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Backend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.BackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendcert/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendclient/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendclient/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendClient
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendClient{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendClient")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendClientList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendconfigidentity/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendconfigidentity/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfigIdentity
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfigIdentity{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfigIdentity")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigIdentityList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendidentitywhitelist/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendidentitywhitelist/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendIdentityWhitelist
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendIdentityWhitelist{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendIdentityWhitelist")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendIdentityWhitelistList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendlogin/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendlogin/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendLogin
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendLogin{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendLogin")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendLoginList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendroletag/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendroletag/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoleTag
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoleTag{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoleTag")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleTagList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendroletagblacklist/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendroletagblacklist/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRoletagBlacklist
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRoletagBlacklist{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRoletagBlacklist")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoletagBlacklistList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/authbackendstsrole/zz_controller.go
+++ b/internal/controller/namespaced/aws/authbackendstsrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendStsRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendStsRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendStsRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendStsRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/aws/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/aws/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/aws/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/azure/authbackendconfig/zz_controller.go
+++ b/internal/controller/namespaced/azure/authbackendconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/azure/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/azure/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/azure/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/azure/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/azure/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/azure/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/cert/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/cert/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/consul/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/consul/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/consul/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/consul/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/database/secretbackendconnection/zz_controller.go
+++ b/internal/controller/namespaced/database/secretbackendconnection/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConnection
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConnection{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConnection")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConnectionList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/database/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/database/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/database/secretbackendstaticrole/zz_controller.go
+++ b/internal/controller/namespaced/database/secretbackendstaticrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendStaticRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendStaticRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendStaticRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendStaticRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/database/secretsmount/zz_controller.go
+++ b/internal/controller/namespaced/database/secretsmount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretsMount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretsMount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretsMount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretsMountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/egp/policy/zz_controller.go
+++ b/internal/controller/namespaced/egp/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/authbackend/zz_controller.go
+++ b/internal/controller/namespaced/gcp/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/gcp/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/gcp/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/secretimpersonatedaccount/zz_controller.go
+++ b/internal/controller/namespaced/gcp/secretimpersonatedaccount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretImpersonatedAccount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretImpersonatedAccount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretImpersonatedAccount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretImpersonatedAccountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/secretroleset/zz_controller.go
+++ b/internal/controller/namespaced/gcp/secretroleset/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRoleset
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRoleset{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRoleset")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRolesetList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/gcp/secretstaticaccount/zz_controller.go
+++ b/internal/controller/namespaced/gcp/secretstaticaccount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretStaticAccount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretStaticAccount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretStaticAccount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretStaticAccountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/generic/endpoint/zz_controller.go
+++ b/internal/controller/namespaced/generic/endpoint/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Endpoint
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Endpoint{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Endpoint")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EndpointList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/generic/secret/zz_controller.go
+++ b/internal/controller/namespaced/generic/secret/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Secret
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Secret")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/github/authbackend/zz_controller.go
+++ b/internal/controller/namespaced/github/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/github/team/zz_controller.go
+++ b/internal/controller/namespaced/github/team/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Team
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Team{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Team")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TeamList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/github/user/zz_controller.go
+++ b/internal/controller/namespaced/github/user/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.User
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.User{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.User")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.UserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/entity/zz_controller.go
+++ b/internal/controller/namespaced/identity/entity/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Entity
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Entity{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Entity")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/entityalias/zz_controller.go
+++ b/internal/controller/namespaced/identity/entityalias/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.EntityAlias
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.EntityAlias{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.EntityAlias")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityAliasList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/entitypolicies/zz_controller.go
+++ b/internal/controller/namespaced/identity/entitypolicies/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.EntityPolicies
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.EntityPolicies{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.EntityPolicies")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.EntityPoliciesList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/group/zz_controller.go
+++ b/internal/controller/namespaced/identity/group/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Group
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Group{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Group")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/groupalias/zz_controller.go
+++ b/internal/controller/namespaced/identity/groupalias/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupAlias
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupAlias{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupAlias")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupAliasList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/groupmemberentityids/zz_controller.go
+++ b/internal/controller/namespaced/identity/groupmemberentityids/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupMemberEntityIds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupMemberEntityIds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupMemberEntityIds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupMemberEntityIdsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/groupmembergroupids/zz_controller.go
+++ b/internal/controller/namespaced/identity/groupmembergroupids/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupMemberGroupIds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupMemberGroupIds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupMemberGroupIds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupMemberGroupIdsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/grouppolicies/zz_controller.go
+++ b/internal/controller/namespaced/identity/grouppolicies/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.GroupPolicies
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.GroupPolicies{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.GroupPolicies")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.GroupPoliciesList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/mfaduo/zz_controller.go
+++ b/internal/controller/namespaced/identity/mfaduo/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaDuo
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaDuo{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaDuo")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaDuoList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/mfaloginenforcement/zz_controller.go
+++ b/internal/controller/namespaced/identity/mfaloginenforcement/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaLoginEnforcement
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaLoginEnforcement{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaLoginEnforcement")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaLoginEnforcementList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/mfaokta/zz_controller.go
+++ b/internal/controller/namespaced/identity/mfaokta/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaOkta
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaOkta{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaOkta")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaOktaList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/mfapingid/zz_controller.go
+++ b/internal/controller/namespaced/identity/mfapingid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaPingid
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaPingid{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaPingid")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaPingidList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/mfatotp/zz_controller.go
+++ b/internal/controller/namespaced/identity/mfatotp/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.MfaTotp
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.MfaTotp{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.MfaTotp")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MfaTotpList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidc/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidc/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Oidc
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Oidc{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Oidc")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidcassignment/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidcassignment/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcAssignment
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcAssignment{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcAssignment")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcAssignmentList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidcclient/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidcclient/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcClient
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcClient{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcClient")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcClientList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidckey/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidckey/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcKey
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcKey{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcKey")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcKeyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidckeyallowedclientid/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidckeyallowedclientid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcKeyAllowedClientID
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcKeyAllowedClientID{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcKeyAllowedClientID")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcKeyAllowedClientIDList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidcprovider/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidcprovider/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcProvider
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcProvider{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcProvider")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcProviderList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidcrole/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidcrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/identity/oidcscope/zz_controller.go
+++ b/internal/controller/namespaced/identity/oidcscope/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.OidcScope
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.OidcScope{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.OidcScope")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OidcScopeList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/jwt/authbackend/zz_controller.go
+++ b/internal/controller/namespaced/jwt/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/jwt/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/jwt/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kmip/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/kmip/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kmip/secretrole/zz_controller.go
+++ b/internal/controller/namespaced/kmip/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kmip/secretscope/zz_controller.go
+++ b/internal/controller/namespaced/kmip/secretscope/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretScope
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretScope{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretScope")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretScopeList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kubernetes/authbackendconfig/zz_controller.go
+++ b/internal/controller/namespaced/kubernetes/authbackendconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kubernetes/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/kubernetes/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kubernetes/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/kubernetes/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kubernetes/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/kubernetes/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kv/secret/zz_controller.go
+++ b/internal/controller/namespaced/kv/secret/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Secret
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Secret{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Secret")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kv/secretbackendv2/zz_controller.go
+++ b/internal/controller/namespaced/kv/secretbackendv2/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendV2
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendV2{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendV2")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendV2List{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/kv/secretv2/zz_controller.go
+++ b/internal/controller/namespaced/kv/secretv2/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretV2
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretV2{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretV2")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretV2List{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ldap/authbackend/zz_controller.go
+++ b/internal/controller/namespaced/ldap/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ldap/authbackendgroup/zz_controller.go
+++ b/internal/controller/namespaced/ldap/authbackendgroup/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendGroup
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendGroup{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendGroup")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendGroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ldap/authbackenduser/zz_controller.go
+++ b/internal/controller/namespaced/ldap/authbackenduser/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendUser
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendUser{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendUser")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendUserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/managed/keys/zz_controller.go
+++ b/internal/controller/namespaced/managed/keys/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Keys
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Keys{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Keys")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.KeysList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mfa/duo/zz_controller.go
+++ b/internal/controller/namespaced/mfa/duo/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Duo
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Duo{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Duo")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.DuoList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mfa/okta/zz_controller.go
+++ b/internal/controller/namespaced/mfa/okta/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Okta
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Okta{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Okta")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.OktaList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mfa/pingid/zz_controller.go
+++ b/internal/controller/namespaced/mfa/pingid/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Pingid
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Pingid{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Pingid")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PingidList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mfa/totp/zz_controller.go
+++ b/internal/controller/namespaced/mfa/totp/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Totp
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Totp{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Totp")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TotpList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mongodbatlas/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/mongodbatlas/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/mongodbatlas/secretrole/zz_controller.go
+++ b/internal/controller/namespaced/mongodbatlas/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/nomad/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/nomad/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/nomad/secretrole/zz_controller.go
+++ b/internal/controller/namespaced/nomad/secretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/okta/authbackend/zz_controller.go
+++ b/internal/controller/namespaced/okta/authbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/okta/authbackendgroup/zz_controller.go
+++ b/internal/controller/namespaced/okta/authbackendgroup/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendGroup
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendGroup{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendGroup")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendGroupList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/okta/authbackenduser/zz_controller.go
+++ b/internal/controller/namespaced/okta/authbackenduser/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendUser
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendUser{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendUser")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendUserList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/password/policy/zz_controller.go
+++ b/internal/controller/namespaced/password/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendcert/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendconfigca/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendconfigca/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConfigCA
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConfigCA{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConfigCA")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConfigCAList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendconfigurls/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendconfigurls/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendConfigUrls
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendConfigUrls{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendConfigUrls")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendConfigUrlsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendcrlconfig/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendcrlconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCrlConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCrlConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCrlConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCrlConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendintermediatecertrequest/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendintermediatecertrequest/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendIntermediateCertRequest
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendIntermediateCertRequest{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendIntermediateCertRequest")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendIntermediateCertRequestList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendintermediatesetsigned/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendintermediatesetsigned/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendIntermediateSetSigned
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendIntermediateSetSigned{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendIntermediateSetSigned")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendIntermediateSetSignedList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendrootcert/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendrootcert/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRootCert
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRootCert{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRootCert")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRootCertList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendrootsignintermediate/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendrootsignintermediate/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRootSignIntermediate
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRootSignIntermediate{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRootSignIntermediate")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRootSignIntermediateList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/pki/secretbackendsign/zz_controller.go
+++ b/internal/controller/namespaced/pki/secretbackendsign/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendSign
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendSign{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendSign")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendSignList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/quota/leasecount/zz_controller.go
+++ b/internal/controller/namespaced/quota/leasecount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.LeaseCount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.LeaseCount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.LeaseCount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.LeaseCountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/quota/ratelimit/zz_controller.go
+++ b/internal/controller/namespaced/quota/ratelimit/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.RateLimit
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.RateLimit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.RateLimit")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RateLimitList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/rabbitmq/secretbackend/zz_controller.go
+++ b/internal/controller/namespaced/rabbitmq/secretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/rabbitmq/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/rabbitmq/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/raft/autopilot/zz_controller.go
+++ b/internal/controller/namespaced/raft/autopilot/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Autopilot
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Autopilot{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Autopilot")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AutopilotList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/raft/snapshotagentconfig/zz_controller.go
+++ b/internal/controller/namespaced/raft/snapshotagentconfig/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SnapshotAgentConfig
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SnapshotAgentConfig{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SnapshotAgentConfig")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SnapshotAgentConfigList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/rgp/policy/zz_controller.go
+++ b/internal/controller/namespaced/rgp/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ssh/secretbackendca/zz_controller.go
+++ b/internal/controller/namespaced/ssh/secretbackendca/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendCA
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendCA{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendCA")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendCAList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/ssh/secretbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/ssh/secretbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/terraform/cloudsecretbackend/zz_controller.go
+++ b/internal/controller/namespaced/terraform/cloudsecretbackend/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretBackend
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretBackend{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretBackend")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretBackendList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/terraform/cloudsecretcreds/zz_controller.go
+++ b/internal/controller/namespaced/terraform/cloudsecretcreds/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretCreds
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretCreds{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretCreds")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretCredsList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/terraform/cloudsecretrole/zz_controller.go
+++ b/internal/controller/namespaced/terraform/cloudsecretrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.CloudSecretRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.CloudSecretRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.CloudSecretRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.CloudSecretRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/token/authbackendrole/zz_controller.go
+++ b/internal/controller/namespaced/token/authbackendrole/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.AuthBackendRole
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.AuthBackendRole{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.AuthBackendRole")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuthBackendRoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/transform/alphabet/zz_controller.go
+++ b/internal/controller/namespaced/transform/alphabet/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Alphabet
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Alphabet{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Alphabet")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AlphabetList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/transform/role/zz_controller.go
+++ b/internal/controller/namespaced/transform/role/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Role
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Role{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Role")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.RoleList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/transform/template/zz_controller.go
+++ b/internal/controller/namespaced/transform/template/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Template
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Template{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Template")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TemplateList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/transform/transformation/zz_controller.go
+++ b/internal/controller/namespaced/transform/transformation/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Transformation
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Transformation{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Transformation")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TransformationList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/transit/secretbackendkey/zz_controller.go
+++ b/internal/controller/namespaced/transit/secretbackendkey/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.SecretBackendKey
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.SecretBackendKey{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.SecretBackendKey")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.SecretBackendKeyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/vault/audit/zz_controller.go
+++ b/internal/controller/namespaced/vault/audit/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Audit
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Audit{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Audit")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.AuditList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/vault/mount/zz_controller.go
+++ b/internal/controller/namespaced/vault/mount/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Mount
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Mount{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Mount")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.MountList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/vault/policy/zz_controller.go
+++ b/internal/controller/namespaced/vault/policy/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Policy
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Policy{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Policy")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.PolicyList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/vault/token/zz_controller.go
+++ b/internal/controller/namespaced/vault/token/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.Token
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.Token{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.Token")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.TokenList{}, o.MetricOptions.PollStateMetricInterval,

--- a/internal/controller/namespaced/vault/vaultnamespace/zz_controller.go
+++ b/internal/controller/namespaced/vault/vaultnamespace/zz_controller.go
@@ -66,15 +66,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1alpha1.VaultNamespace
-	// if they're enabled.
-	if o.StartWebhooks {
-		if err := ctrl.NewWebhookManagedBy(mgr, &v1alpha1.VaultNamespace{}).
-			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1alpha1.VaultNamespace")
-		}
-	}
-
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
 			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha1.VaultNamespaceList{}, o.MetricOptions.PollStateMetricInterval,


### PR DESCRIPTION
# Description
Backport of https://github.com/upbound/provider-vault/pull/160 to `release-4.0`.

This PR also bump upjet to commit `c73cc3a2d247`, which allows custom controller setup aggregator templates.
