### PR TITLE
chore(deps): bump terraform-provider-vault to v5.9.0-upjet.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -295,4 +295,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-provider-vault => github.com/upbound/terraform-provider-vault v0.0.0-20260609124043-4bb4f076a4b5 // v5.9.0-upjet.1
+replace github.com/hashicorp/terraform-provider-vault => github.com/upbound/terraform-provider-vault v0.0.0-20260902052604-3bc68cca9d21 // v5.9.0-upjet.2

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/upbound/terraform-provider-vault v0.0.0-20260609124043-4bb4f076a4b5 h1:5YuwCZH7uYqiEyHOsE+PKKof6Tzi7/HpqWcPTrRaK+s=
-github.com/upbound/terraform-provider-vault v0.0.0-20260609124043-4bb4f076a4b5/go.mod h1:7U/YuNJ+PpisSCDosMTulfOrPl17b3lfLAg/JeT6p4k=
+github.com/upbound/terraform-provider-vault v0.0.0-20260902052604-3bc68cca9d21 h1:eqoHBeZ2KQUBa+44Y05rZ9Nx3NDt6EDBkYckFhIcYdY=
+github.com/upbound/terraform-provider-vault v0.0.0-20260902052604-3bc68cca9d21/go.mod h1:7U/YuNJ+PpisSCDosMTulfOrPl17b3lfLAg/JeT6p4k=
 github.com/upbound/uptest v0.12.1-0.20260728095952-c230a8044006 h1:j4vaCxXdTtUmNUMX8UAXbDtgE/Tw6s2WLEJryUyBGiY=
 github.com/upbound/uptest v0.12.1-0.20260728095952-c230a8044006/go.mod h1:cuujm9YkUiUW2CC0XRIh6bVPDjfS8kbGI9t5T5TSJzk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
## Description

Bumps the `hashicorp/terraform-provider-vault` replace directive from `v5.9.0-upjet.1` (`4bb4f076`) to `v5.9.0-upjet.2` (`3bc68cca`), picking up upbound/terraform-provider-vault#3.

`GetResourceDataBool` returned the default for every boolean provider config field whenever `d.GetRawConfig()` was null. That is the normal path here: upjet no-fork calls `schema.Provider.Configure` directly, so there is no terraform plan/apply cycle to populate the raw config. `skip_child_token: true` in a `ProviderConfig` did nothing, and any `ProviderConfig` authenticating with a batch token failed on every observe:

```
observe failed: failed to observe the resource: [{0 failed to create limited child token:
Error making API request... batch tokens cannot create more tokens
```

The fix had to live in the fork, since `GetResourceDataBool` is under `internal/` and unreachable from here.

Fixes #122.

## What this changes at runtime

`skip_child_token`, `skip_tls_verify`, `skip_get_vault_version` and `add_address_to_env` now take effect instead of always using their defaults.

`set_namespace_from_token` keeps its documented `true` default. `internal/clients/vault.go` never writes that key, so `GetOkExists` reports it unset and the fallback chain lands on the default. An earlier revision of the fork PR used `d.Get()`, which would have flipped it to `false` on every configure; that was the blocking finding on the review and it was fixed before merge.

## Verification

- `go build ./...` and `go vet ./internal/...` clean.
- `go test ./internal/...` reports no test files in any of the 256 packages, so there is nothing to run on this branch. #164 adds the first coverage of the no-fork configure path.
- Diff is 1 line of `go.mod` and 2 of `go.sum` after `go mod tidy`. No transitive churn.
- Confirmed the fix is in the pinned module, not just in the PR: `GetOkExists` is present at `internal/provider/meta.go` in `v0.0.0-20260902052604-3bc68cca9d21` in the module cache.
- The merged fork code is byte-identical, apart from one comment, to the branch I ran acceptance tests on: **480 PASS / 243 SKIP / 12 FAIL** against a clean Vault 1.20.4 over `./vault` and `./internal/provider`, failure set identical to base. The 12 are environmental: Enterprise managed keys, Enterprise secrets sync, in-cluster k8s auth, Consul, and two AWS login tests that need a shared config profile.

I have not run this against a live control plane. Worth one `ProviderConfig` with a batch token and `skipChildToken: true` before release.

## Related and follow-ups

- #164 exposes `setNamespaceFromToken` in the `ProviderConfig` spec and adds tests for the configure path. Independent of this PR; either can merge first.
- Pre-existing, not introduced here: the four bools above are plain `bool` in the spec and written unconditionally, so `GetOkExists` always finds them set and their `VAULT_*` environment variables can never take effect through a `ProviderConfig`. Raised in #164.
