### PR TITLE
fix: set a no-op controller-runtime logger

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -116,10 +117,14 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-vault"))
+	// controller-runtime requires a logger to be set explicitly, otherwise it
+	// prints a "log.SetLogger(...) was never called" warning with a stack
+	// trace and discards its logs anyway. Give it one that writes nowhere
+	// unless we are running in debug mode.
+	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
+		// The controller-runtime logger is *very* verbose even at info
+		// level, so we only provide it a real logger in debug mode.
 		ctrl.SetLogger(zl)
 	}
 


### PR DESCRIPTION
### Description of your changes

controller-runtime expects `log.SetLogger` to be called before its first use. The provider only did so under `--debug`, so every non-debug run printed

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 453 [running]:
	>  runtime/debug.Stack()
	...
	>  sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue.(*priorityqueue[...]).logState(...)
```

as soon as the first work queue started, and users read the stack trace as an error.

This sets a logger that writes to `io.Discard` right after the provider's own logger is constructed, and keeps swapping in the real zap logger in debug mode. controller-runtime output stays suppressed by default, exactly as before, only without the warning. This is the same pattern provider-helm and the upjet-based providers already use.

One deliberate difference from provider-upjet-aws and provider-upjet-azuread: this change does not also redirect the standard library `log` package to `io.Discard`. In this provider the Terraform Vault provider logs through stdlib `log`, and those `[DEBUG] Reading ... from Vault` lines are what people rely on under `--debug` to see Vault API errors (see the discussion in #33).

Fixes #33

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
`make reviewable test`

Ran the current v4 binary and the patched binary side by side against a kind cluster with the provider CRDs installed, for 55 seconds each, without `--debug`:

| Binary | Output |
|---|---|
| current `main` | `Beta feature enabled` info line, then the `log.SetLogger(...) was never called` warning with a 15-line stack trace within one second of start |
| this branch | `Beta feature enabled` info line only |

The `--debug` path is unchanged: `ctrl.SetLogger(zl)` still runs after the discard logger is set.

[contribution process]: https://git.io/fj2m9
