### PR TITLE
fix: mark snapshot agent credentials as sensitive

### DIFF
--- a/apis/cluster/raft/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/raft/v1alpha1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@ Copyright 2022 Upbound Inc.
 package v1alpha1
 
 import (
+	"github.com/crossplane/crossplane/apis/v2/core/v2"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -356,19 +357,19 @@ func (in *SnapshotAgentConfigInitParameters) DeepCopyInto(out *SnapshotAgentConf
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
+	if in.AwsSecretAccessKeySecretRef != nil {
+		in, out := &in.AwsSecretAccessKeySecretRef, &out.AwsSecretAccessKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
+	if in.AwsSessionTokenSecretRef != nil {
+		in, out := &in.AwsSessionTokenSecretRef, &out.AwsSessionTokenSecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
+	if in.AzureAccountKeySecretRef != nil {
+		in, out := &in.AzureAccountKeySecretRef, &out.AzureAccountKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
 	if in.AzureAccountName != nil {
@@ -421,9 +422,9 @@ func (in *SnapshotAgentConfigInitParameters) DeepCopyInto(out *SnapshotAgentConf
 		*out = new(string)
 		**out = **in
 	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
-		*out = new(string)
+	if in.GoogleServiceAccountKeySecretRef != nil {
+		in, out := &in.GoogleServiceAccountKeySecretRef, &out.GoogleServiceAccountKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
 	if in.IntervalSeconds != nil {
@@ -558,21 +559,6 @@ func (in *SnapshotAgentConfigObservation) DeepCopyInto(out *SnapshotAgentConfigO
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
-		**out = **in
-	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
-		**out = **in
-	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.AzureAccountName != nil {
 		in, out := &in.AzureAccountName, &out.AzureAccountName
 		*out = new(string)
@@ -620,11 +606,6 @@ func (in *SnapshotAgentConfigObservation) DeepCopyInto(out *SnapshotAgentConfigO
 	}
 	if in.GoogleGcsBucket != nil {
 		in, out := &in.GoogleGcsBucket, &out.GoogleGcsBucket
-		*out = new(string)
-		**out = **in
-	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
 		*out = new(string)
 		**out = **in
 	}
@@ -733,19 +714,19 @@ func (in *SnapshotAgentConfigParameters) DeepCopyInto(out *SnapshotAgentConfigPa
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
+	if in.AwsSecretAccessKeySecretRef != nil {
+		in, out := &in.AwsSecretAccessKeySecretRef, &out.AwsSecretAccessKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
+	if in.AwsSessionTokenSecretRef != nil {
+		in, out := &in.AwsSessionTokenSecretRef, &out.AwsSessionTokenSecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
+	if in.AzureAccountKeySecretRef != nil {
+		in, out := &in.AzureAccountKeySecretRef, &out.AzureAccountKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
 	if in.AzureAccountName != nil {
@@ -798,9 +779,9 @@ func (in *SnapshotAgentConfigParameters) DeepCopyInto(out *SnapshotAgentConfigPa
 		*out = new(string)
 		**out = **in
 	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
-		*out = new(string)
+	if in.GoogleServiceAccountKeySecretRef != nil {
+		in, out := &in.GoogleServiceAccountKeySecretRef, &out.GoogleServiceAccountKeySecretRef
+		*out = new(v2.SecretKeySelector)
 		**out = **in
 	}
 	if in.IntervalSeconds != nil {

--- a/apis/cluster/raft/v1alpha1/zz_snapshotagentconfig_terraformed.go
+++ b/apis/cluster/raft/v1alpha1/zz_snapshotagentconfig_terraformed.go
@@ -21,7 +21,7 @@ func (mg *SnapshotAgentConfig) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this SnapshotAgentConfig
 func (tr *SnapshotAgentConfig) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"aws_secret_access_key": "awsSecretAccessKeySecretRef", "aws_session_token": "awsSessionTokenSecretRef", "azure_account_key": "azureAccountKeySecretRef", "google_service_account_key": "googleServiceAccountKeySecretRef"}
 }
 
 // GetObservation of this SnapshotAgentConfig

--- a/apis/cluster/raft/v1alpha1/zz_snapshotagentconfig_types.go
+++ b/apis/cluster/raft/v1alpha1/zz_snapshotagentconfig_types.go
@@ -62,15 +62,15 @@ type SnapshotAgentConfigInitParameters struct {
 
 	// AWS secret access key.
 	// AWS secret access key.
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
+	AwsSecretAccessKeySecretRef *v2.SecretKeySelector `json:"awsSecretAccessKeySecretRef,omitempty" tf:"-"`
 
 	// AWS session token.
 	// AWS session token.
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
+	AwsSessionTokenSecretRef *v2.SecretKeySelector `json:"awsSessionTokenSecretRef,omitempty" tf:"-"`
 
 	// Azure account key. Required when azure_auth_mode = "shared".
 	// Azure account key. Required when azure_auth_mode is 'shared'.
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
+	AzureAccountKeySecretRef *v2.SecretKeySelector `json:"azureAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Azure account name.
 	// Azure account name.
@@ -123,7 +123,7 @@ type SnapshotAgentConfigInitParameters struct {
 	// Google service account key in JSON format.
 	// The raw value looks like this:
 	// Google service account key in JSON format.
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
+	GoogleServiceAccountKeySecretRef *v2.SecretKeySelector `json:"googleServiceAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Time (in seconds) between snapshots.
 	// Number of seconds between snapshots.
@@ -213,18 +213,6 @@ type SnapshotAgentConfigObservation struct {
 	// Use AES256 to encrypt bucket contents.
 	AwsS3ServerSideEncryption *bool `json:"awsS3ServerSideEncryption,omitempty" tf:"aws_s3_server_side_encryption,omitempty"`
 
-	// AWS secret access key.
-	// AWS secret access key.
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
-
-	// AWS session token.
-	// AWS session token.
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
-
-	// Azure account key. Required when azure_auth_mode = "shared".
-	// Azure account key. Required when azure_auth_mode is 'shared'.
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
-
 	// Azure account name.
 	// Azure account name.
 	AzureAccountName *string `json:"azureAccountName,omitempty" tf:"azure_account_name,omitempty"`
@@ -272,11 +260,6 @@ type SnapshotAgentConfigObservation struct {
 	// GCS bucket to write snapshots to.
 	// GCS bucket to write snapshots to.
 	GoogleGcsBucket *string `json:"googleGcsBucket,omitempty" tf:"google_gcs_bucket,omitempty"`
-
-	// Google service account key in JSON format.
-	// The raw value looks like this:
-	// Google service account key in JSON format.
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
@@ -381,17 +364,17 @@ type SnapshotAgentConfigParameters struct {
 	// AWS secret access key.
 	// AWS secret access key.
 	// +kubebuilder:validation:Optional
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
+	AwsSecretAccessKeySecretRef *v2.SecretKeySelector `json:"awsSecretAccessKeySecretRef,omitempty" tf:"-"`
 
 	// AWS session token.
 	// AWS session token.
 	// +kubebuilder:validation:Optional
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
+	AwsSessionTokenSecretRef *v2.SecretKeySelector `json:"awsSessionTokenSecretRef,omitempty" tf:"-"`
 
 	// Azure account key. Required when azure_auth_mode = "shared".
 	// Azure account key. Required when azure_auth_mode is 'shared'.
 	// +kubebuilder:validation:Optional
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
+	AzureAccountKeySecretRef *v2.SecretKeySelector `json:"azureAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Azure account name.
 	// Azure account name.
@@ -455,7 +438,7 @@ type SnapshotAgentConfigParameters struct {
 	// The raw value looks like this:
 	// Google service account key in JSON format.
 	// +kubebuilder:validation:Optional
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
+	GoogleServiceAccountKeySecretRef *v2.SecretKeySelector `json:"googleServiceAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Time (in seconds) between snapshots.
 	// Number of seconds between snapshots.

--- a/apis/namespaced/raft/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/raft/v1alpha1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@ Copyright 2022 Upbound Inc.
 package v1alpha1
 
 import (
+	"github.com/crossplane/crossplane/apis/v2/core/v2"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -356,19 +357,19 @@ func (in *SnapshotAgentConfigInitParameters) DeepCopyInto(out *SnapshotAgentConf
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
+	if in.AwsSecretAccessKeySecretRef != nil {
+		in, out := &in.AwsSecretAccessKeySecretRef, &out.AwsSecretAccessKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
+	if in.AwsSessionTokenSecretRef != nil {
+		in, out := &in.AwsSessionTokenSecretRef, &out.AwsSessionTokenSecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
+	if in.AzureAccountKeySecretRef != nil {
+		in, out := &in.AzureAccountKeySecretRef, &out.AzureAccountKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.AzureAccountName != nil {
@@ -421,9 +422,9 @@ func (in *SnapshotAgentConfigInitParameters) DeepCopyInto(out *SnapshotAgentConf
 		*out = new(string)
 		**out = **in
 	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
-		*out = new(string)
+	if in.GoogleServiceAccountKeySecretRef != nil {
+		in, out := &in.GoogleServiceAccountKeySecretRef, &out.GoogleServiceAccountKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.IntervalSeconds != nil {
@@ -558,21 +559,6 @@ func (in *SnapshotAgentConfigObservation) DeepCopyInto(out *SnapshotAgentConfigO
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
-		**out = **in
-	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
-		**out = **in
-	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.AzureAccountName != nil {
 		in, out := &in.AzureAccountName, &out.AzureAccountName
 		*out = new(string)
@@ -620,11 +606,6 @@ func (in *SnapshotAgentConfigObservation) DeepCopyInto(out *SnapshotAgentConfigO
 	}
 	if in.GoogleGcsBucket != nil {
 		in, out := &in.GoogleGcsBucket, &out.GoogleGcsBucket
-		*out = new(string)
-		**out = **in
-	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
 		*out = new(string)
 		**out = **in
 	}
@@ -733,19 +714,19 @@ func (in *SnapshotAgentConfigParameters) DeepCopyInto(out *SnapshotAgentConfigPa
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AwsSecretAccessKey != nil {
-		in, out := &in.AwsSecretAccessKey, &out.AwsSecretAccessKey
-		*out = new(string)
+	if in.AwsSecretAccessKeySecretRef != nil {
+		in, out := &in.AwsSecretAccessKeySecretRef, &out.AwsSecretAccessKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
-	if in.AwsSessionToken != nil {
-		in, out := &in.AwsSessionToken, &out.AwsSessionToken
-		*out = new(string)
+	if in.AwsSessionTokenSecretRef != nil {
+		in, out := &in.AwsSessionTokenSecretRef, &out.AwsSessionTokenSecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
-	if in.AzureAccountKey != nil {
-		in, out := &in.AzureAccountKey, &out.AzureAccountKey
-		*out = new(string)
+	if in.AzureAccountKeySecretRef != nil {
+		in, out := &in.AzureAccountKeySecretRef, &out.AzureAccountKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.AzureAccountName != nil {
@@ -798,9 +779,9 @@ func (in *SnapshotAgentConfigParameters) DeepCopyInto(out *SnapshotAgentConfigPa
 		*out = new(string)
 		**out = **in
 	}
-	if in.GoogleServiceAccountKey != nil {
-		in, out := &in.GoogleServiceAccountKey, &out.GoogleServiceAccountKey
-		*out = new(string)
+	if in.GoogleServiceAccountKeySecretRef != nil {
+		in, out := &in.GoogleServiceAccountKeySecretRef, &out.GoogleServiceAccountKeySecretRef
+		*out = new(v2.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.IntervalSeconds != nil {

--- a/apis/namespaced/raft/v1alpha1/zz_snapshotagentconfig_terraformed.go
+++ b/apis/namespaced/raft/v1alpha1/zz_snapshotagentconfig_terraformed.go
@@ -21,7 +21,7 @@ func (mg *SnapshotAgentConfig) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this SnapshotAgentConfig
 func (tr *SnapshotAgentConfig) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"aws_secret_access_key": "awsSecretAccessKeySecretRef", "aws_session_token": "awsSessionTokenSecretRef", "azure_account_key": "azureAccountKeySecretRef", "google_service_account_key": "googleServiceAccountKeySecretRef"}
 }
 
 // GetObservation of this SnapshotAgentConfig

--- a/apis/namespaced/raft/v1alpha1/zz_snapshotagentconfig_types.go
+++ b/apis/namespaced/raft/v1alpha1/zz_snapshotagentconfig_types.go
@@ -62,15 +62,15 @@ type SnapshotAgentConfigInitParameters struct {
 
 	// AWS secret access key.
 	// AWS secret access key.
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
+	AwsSecretAccessKeySecretRef *v2.LocalSecretKeySelector `json:"awsSecretAccessKeySecretRef,omitempty" tf:"-"`
 
 	// AWS session token.
 	// AWS session token.
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
+	AwsSessionTokenSecretRef *v2.LocalSecretKeySelector `json:"awsSessionTokenSecretRef,omitempty" tf:"-"`
 
 	// Azure account key. Required when azure_auth_mode = "shared".
 	// Azure account key. Required when azure_auth_mode is 'shared'.
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
+	AzureAccountKeySecretRef *v2.LocalSecretKeySelector `json:"azureAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Azure account name.
 	// Azure account name.
@@ -123,7 +123,7 @@ type SnapshotAgentConfigInitParameters struct {
 	// Google service account key in JSON format.
 	// The raw value looks like this:
 	// Google service account key in JSON format.
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
+	GoogleServiceAccountKeySecretRef *v2.LocalSecretKeySelector `json:"googleServiceAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Time (in seconds) between snapshots.
 	// Number of seconds between snapshots.
@@ -213,18 +213,6 @@ type SnapshotAgentConfigObservation struct {
 	// Use AES256 to encrypt bucket contents.
 	AwsS3ServerSideEncryption *bool `json:"awsS3ServerSideEncryption,omitempty" tf:"aws_s3_server_side_encryption,omitempty"`
 
-	// AWS secret access key.
-	// AWS secret access key.
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
-
-	// AWS session token.
-	// AWS session token.
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
-
-	// Azure account key. Required when azure_auth_mode = "shared".
-	// Azure account key. Required when azure_auth_mode is 'shared'.
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
-
 	// Azure account name.
 	// Azure account name.
 	AzureAccountName *string `json:"azureAccountName,omitempty" tf:"azure_account_name,omitempty"`
@@ -272,11 +260,6 @@ type SnapshotAgentConfigObservation struct {
 	// GCS bucket to write snapshots to.
 	// GCS bucket to write snapshots to.
 	GoogleGcsBucket *string `json:"googleGcsBucket,omitempty" tf:"google_gcs_bucket,omitempty"`
-
-	// Google service account key in JSON format.
-	// The raw value looks like this:
-	// Google service account key in JSON format.
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
@@ -381,17 +364,17 @@ type SnapshotAgentConfigParameters struct {
 	// AWS secret access key.
 	// AWS secret access key.
 	// +kubebuilder:validation:Optional
-	AwsSecretAccessKey *string `json:"awsSecretAccessKey,omitempty" tf:"aws_secret_access_key,omitempty"`
+	AwsSecretAccessKeySecretRef *v2.LocalSecretKeySelector `json:"awsSecretAccessKeySecretRef,omitempty" tf:"-"`
 
 	// AWS session token.
 	// AWS session token.
 	// +kubebuilder:validation:Optional
-	AwsSessionToken *string `json:"awsSessionToken,omitempty" tf:"aws_session_token,omitempty"`
+	AwsSessionTokenSecretRef *v2.LocalSecretKeySelector `json:"awsSessionTokenSecretRef,omitempty" tf:"-"`
 
 	// Azure account key. Required when azure_auth_mode = "shared".
 	// Azure account key. Required when azure_auth_mode is 'shared'.
 	// +kubebuilder:validation:Optional
-	AzureAccountKey *string `json:"azureAccountKey,omitempty" tf:"azure_account_key,omitempty"`
+	AzureAccountKeySecretRef *v2.LocalSecretKeySelector `json:"azureAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Azure account name.
 	// Azure account name.
@@ -455,7 +438,7 @@ type SnapshotAgentConfigParameters struct {
 	// The raw value looks like this:
 	// Google service account key in JSON format.
 	// +kubebuilder:validation:Optional
-	GoogleServiceAccountKey *string `json:"googleServiceAccountKey,omitempty" tf:"google_service_account_key,omitempty"`
+	GoogleServiceAccountKeySecretRef *v2.LocalSecretKeySelector `json:"googleServiceAccountKeySecretRef,omitempty" tf:"-"`
 
 	// Time (in seconds) between snapshots.
 	// Number of seconds between snapshots.

--- a/config/vault/config.go
+++ b/config/vault/config.go
@@ -2,10 +2,26 @@ package vault
 
 import "github.com/crossplane/upjet/v2/pkg/config"
 
-// ConfigureNamespace configures the namespace resource.
+// Configure applies the hand-written resource configurations for the
+// resources in the root vault group.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("vault_namespace", func(r *config.Resource) {
 		r.Kind = "VaultNamespace"
 		r.ShortGroup = "vault"
+	})
+
+	p.AddResourceConfigurator("vault_raft_snapshot_agent_config", func(r *config.Resource) {
+		// The upstream Terraform schema declares the cloud storage
+		// credentials as plain strings. They are secrets, so mark them
+		// sensitive to generate *SecretRef fields instead of storing
+		// them in clear text in the spec.
+		for _, key := range []string{
+			"aws_secret_access_key",
+			"aws_session_token",
+			"azure_account_key",
+			"google_service_account_key",
+		} {
+			r.TerraformResource.Schema[key].Sensitive = true
+		}
 	})
 }

--- a/package/crds/raft.vault.m.upbound.io_snapshotagentconfigs.yaml
+++ b/package/crds/raft.vault.m.upbound.io_snapshotagentconfigs.yaml
@@ -114,21 +114,48 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
+                  awsSecretAccessKeySecretRef:
                     description: |-
                       AWS secret access key.
                       AWS secret access key.
-                    type: string
-                  awsSessionToken:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  awsSessionTokenSecretRef:
                     description: |-
                       AWS session token.
                       AWS session token.
-                    type: string
-                  azureAccountKey:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  azureAccountKeySecretRef:
                     description: |-
                       Azure account key. Required when azure_auth_mode = "shared".
                       Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -187,12 +214,21 @@ spec:
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
                     type: string
-                  googleServiceAccountKey:
+                  googleServiceAccountKeySecretRef:
                     description: |-
                       Google service account key in JSON format.
                       The raw value looks like this:
                       Google service account key in JSON format.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   intervalSeconds:
                     description: |-
                       Time (in seconds) between snapshots.
@@ -309,21 +345,48 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
+                  awsSecretAccessKeySecretRef:
                     description: |-
                       AWS secret access key.
                       AWS secret access key.
-                    type: string
-                  awsSessionToken:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  awsSessionTokenSecretRef:
                     description: |-
                       AWS session token.
                       AWS session token.
-                    type: string
-                  azureAccountKey:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  azureAccountKeySecretRef:
                     description: |-
                       Azure account key. Required when azure_auth_mode = "shared".
                       Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -382,12 +445,21 @@ spec:
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
                     type: string
-                  googleServiceAccountKey:
+                  googleServiceAccountKeySecretRef:
                     description: |-
                       Google service account key in JSON format.
                       The raw value looks like this:
                       Google service account key in JSON format.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   intervalSeconds:
                     description: |-
                       Time (in seconds) between snapshots.
@@ -571,21 +643,6 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
-                    description: |-
-                      AWS secret access key.
-                      AWS secret access key.
-                    type: string
-                  awsSessionToken:
-                    description: |-
-                      AWS session token.
-                      AWS session token.
-                    type: string
-                  azureAccountKey:
-                    description: |-
-                      Azure account key. Required when azure_auth_mode = "shared".
-                      Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -643,12 +700,6 @@ spec:
                     description: |-
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
-                    type: string
-                  googleServiceAccountKey:
-                    description: |-
-                      Google service account key in JSON format.
-                      The raw value looks like this:
-                      Google service account key in JSON format.
                     type: string
                   id:
                     type: string

--- a/package/crds/raft.vault.upbound.io_snapshotagentconfigs.yaml
+++ b/package/crds/raft.vault.upbound.io_snapshotagentconfigs.yaml
@@ -128,21 +128,63 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
+                  awsSecretAccessKeySecretRef:
                     description: |-
                       AWS secret access key.
                       AWS secret access key.
-                    type: string
-                  awsSessionToken:
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  awsSessionTokenSecretRef:
                     description: |-
                       AWS session token.
                       AWS session token.
-                    type: string
-                  azureAccountKey:
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  azureAccountKeySecretRef:
                     description: |-
                       Azure account key. Required when azure_auth_mode = "shared".
                       Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -201,12 +243,26 @@ spec:
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
                     type: string
-                  googleServiceAccountKey:
+                  googleServiceAccountKeySecretRef:
                     description: |-
                       Google service account key in JSON format.
                       The raw value looks like this:
                       Google service account key in JSON format.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   intervalSeconds:
                     description: |-
                       Time (in seconds) between snapshots.
@@ -323,21 +379,63 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
+                  awsSecretAccessKeySecretRef:
                     description: |-
                       AWS secret access key.
                       AWS secret access key.
-                    type: string
-                  awsSessionToken:
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  awsSessionTokenSecretRef:
                     description: |-
                       AWS session token.
                       AWS session token.
-                    type: string
-                  azureAccountKey:
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  azureAccountKeySecretRef:
                     description: |-
                       Azure account key. Required when azure_auth_mode = "shared".
                       Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -396,12 +494,26 @@ spec:
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
                     type: string
-                  googleServiceAccountKey:
+                  googleServiceAccountKeySecretRef:
                     description: |-
                       Google service account key in JSON format.
                       The raw value looks like this:
                       Google service account key in JSON format.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   intervalSeconds:
                     description: |-
                       Time (in seconds) between snapshots.
@@ -613,21 +725,6 @@ spec:
                       Use AES256 to encrypt bucket contents.
                       Use AES256 to encrypt bucket contents.
                     type: boolean
-                  awsSecretAccessKey:
-                    description: |-
-                      AWS secret access key.
-                      AWS secret access key.
-                    type: string
-                  awsSessionToken:
-                    description: |-
-                      AWS session token.
-                      AWS session token.
-                    type: string
-                  azureAccountKey:
-                    description: |-
-                      Azure account key. Required when azure_auth_mode = "shared".
-                      Azure account key. Required when azure_auth_mode is 'shared'.
-                    type: string
                   azureAccountName:
                     description: |-
                       Azure account name.
@@ -685,12 +782,6 @@ spec:
                     description: |-
                       GCS bucket to write snapshots to.
                       GCS bucket to write snapshots to.
-                    type: string
-                  googleServiceAccountKey:
-                    description: |-
-                      Google service account key in JSON format.
-                      The raw value looks like this:
-                      Google service account key in JSON format.
                     type: string
                   id:
                     type: string


### PR DESCRIPTION
### Description of your changes

`SnapshotAgentConfig` exposed the cloud storage credentials of `vault_raft_snapshot_agent_config` as plain strings, because the upstream Terraform schema does not mark them sensitive. This adds a resource configurator that sets `Sensitive` on `aws_secret_access_key`, `aws_session_token`, `azure_account_key` and `google_service_account_key`, and regenerates the resource.

The generated API now has `awsSecretAccessKeySecretRef`, `awsSessionTokenSecretRef`, `azureAccountKeySecretRef` and `googleServiceAccountKeySecretRef` in `spec.forProvider` and `spec.initProvider`, and the plain fields are gone from spec and `status.atProvider`.

This is an in-place change to `v1alpha1`: manifests that set the plain fields must move the value into a Secret and reference it. It's a security bugfix which justifies no api version update

Fixes #101

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Run `make reviewable test`; there is no e2e example for this resource.

[contribution process]: https://git.io/fj2m9
